### PR TITLE
GPII-2200: Moved debug logging to after the fluid.log redirect has been set

### DIFF
--- a/main.js
+++ b/main.js
@@ -30,6 +30,7 @@ if (appIsRunning || gpiiIsRunning) {
 
 require("gpii-windows/index.js");
 require("./src/logging.js");
+gpii.windows.debugLog.logDebugInfo();
 require("./src/app.js");
 
 // This method will be called when Electron has finished


### PR DESCRIPTION
The debug logging was being written to stdout before fluid.doLog was re-written.

Moving the require statements for logging.js before gpii-windows didn't work because getting the settings directory in logging.js depends on the windows context.
