### PR TITLE
GPII-2287 and GPII-2289: Fix provisioning and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,6 @@ cd c:\vagrant\
 npm start
 ```
 
-(If you recieve an error about infusion already having been loaded, delete the folder `node_modules/gpii-windows/node_modules/infusion/` and rerun `npm start`).
-
-
 ### Running the Tests in a VM
 
 Ensure that your virtual box is up and running, then go to the folder with gpii-app and run:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "start": "electron main.js",
-    "test": "electron tests.js"
+    "test": "powershell provisioning/Tests.ps1 -originalBuildScriptPath './node_modules/gpii-windows/provisioning'; electron tests.js"
   },
   "dependencies": {
     "electron": "1.4.1",

--- a/provisioning/Build.ps1
+++ b/provisioning/Build.ps1
@@ -30,7 +30,7 @@ Import-Module $bootstrapModule -Verbose -Force
 # # Run all the windows provisioning scripts
 # ############
 # TODO: Create function for downloading scripts and executing them.
-$windowsBootstrapURL = "https://raw.githubusercontent.com/GPII/windows/hst-2017/provisioning"
+$windowsBootstrapURL = "https://raw.githubusercontent.com/javihernandez/windows/GPII-2287/provisioning"
 try {
     $choco = Join-Path $originalBuildScriptPath "Chocolatey.ps1"
     Write-OutPut "Running windows script: $choco"
@@ -49,15 +49,18 @@ try {
     Write-OutPut "Npm.ps1 FAILED"
     exit 1
 }
-#try {
-#    $build = Join-Path $originalBuildScriptPath "Build-Windows.ps1"
-#    Write-OutPut "Running windows script: $build"
-#    iwr "$windowsBootstrapURL/Build.ps1" -UseBasicParsing -OutFile $build
-#    Invoke-Expression $build -skipNpm
-#} catch {
-#    Write-OutPut "Build.ps1 FAILED"
-#    exit 1
-#}
 
 $npm = "npm" -f $env:SystemDrive
 Invoke-Command $npm "install" $mainDir
+
+try {
+    $tests = Join-Path $originalBuildScriptPath "Tests.ps1"
+    $fullPath = Join-Path $originalBuildScriptPath "../node_modules/gpii-windows/provisioning/"
+    $args = "-originalBuildScriptPath $fullPath"
+    Write-OutPut "Running windows script: $tests"
+    iwr "$windowsBootstrapURL/Tests.ps1" -UseBasicParsing -OutFile $tests
+    Invoke-Expression "$tests $args"
+} catch {
+    Write-OutPut "Tests.ps1 FAILED"
+    exit 1
+}

--- a/provisioning/Build.ps1
+++ b/provisioning/Build.ps1
@@ -30,7 +30,7 @@ Import-Module $bootstrapModule -Verbose -Force
 # # Run all the windows provisioning scripts
 # ############
 # TODO: Create function for downloading scripts and executing them.
-$windowsBootstrapURL = "https://raw.githubusercontent.com/javihernandez/windows/GPII-2287/provisioning"
+$windowsBootstrapURL = "https://raw.githubusercontent.com/GPII/windows/hst-2017/provisioning"
 try {
     $choco = Join-Path $originalBuildScriptPath "Chocolatey.ps1"
     Write-OutPut "Running windows script: $choco"

--- a/provisioning/Installer.ps1
+++ b/provisioning/Installer.ps1
@@ -14,8 +14,8 @@ $projectDir = (Get-Item $provisioningDir).parent.FullName
 
 Import-Module (Join-Path $provisioningDir 'Provisioning.psm1') -Force
 
-$installerRepo = "https://github.com/javihernandez/gpii-wix-installer"
-$installerBranch = "GPII-2290"
+$installerRepo = "https://github.com/GPII/gpii-wix-installer"
+$installerBranch = "HST"
 
 # Obtaining useful tools location.
 $installerDir = Join-Path $env:SystemDrive "installer" # a.k.a. C:\installer\
@@ -34,7 +34,7 @@ $hstToolsDir = Join-Path (Join-Path $installerDir "staging") "gpii-hst-tools"
 if (Test-Path -Path $hstToolsDir){
     rm $hstToolsDir -Recurse -Force
 }
-Invoke-Command $git "clone --branch GPII-2230 https://github.com/javihernandez/gpii-hst-tools $($hstToolsDir)"
+Invoke-Command $git "clone https://github.com/GPII/gpii-hst-tools $($hstToolsDir)"
 
 # Create staging folder
 $stagingWindowsDir = Join-Path (Join-Path $installerDir "staging") "windows"

--- a/provisioning/Installer.ps1
+++ b/provisioning/Installer.ps1
@@ -14,8 +14,8 @@ $projectDir = (Get-Item $provisioningDir).parent.FullName
 
 Import-Module (Join-Path $provisioningDir 'Provisioning.psm1') -Force
 
-$installerRepo = "https://github.com/gpii/gpii-wix-installer"
-$installerBranch = "HST"
+$installerRepo = "https://github.com/javihernandez/gpii-wix-installer"
+$installerBranch = "GPII-2290"
 
 # Obtaining useful tools location.
 $installerDir = Join-Path $env:SystemDrive "installer" # a.k.a. C:\installer\
@@ -34,7 +34,7 @@ $hstToolsDir = Join-Path (Join-Path $installerDir "staging") "gpii-hst-tools"
 if (Test-Path -Path $hstToolsDir){
     rm $hstToolsDir -Recurse -Force
 }
-Invoke-Command $git "clone https://github.com/GPII/gpii-hst-tools $($hstToolsDir)"
+Invoke-Command $git "clone --branch GPII-2230 https://github.com/javihernandez/gpii-hst-tools $($hstToolsDir)"
 
 # Create staging folder
 $stagingWindowsDir = Join-Path (Join-Path $installerDir "staging") "windows"

--- a/tests.js
+++ b/tests.js
@@ -5,14 +5,14 @@ var app = require("electron").app;
 var fluid = require("universal"),
     jqUnit = fluid.require("node-jqunit");
 
+require("gpii-windows/index.js");
+
+require("./node_modules/universal/tests/all-tests.js");
+require("./node_modules/gpii-windows/tests/UnitTests.js");
+
 app.on("ready", function () {
-	require("./node_modules/gpii-windows/node_modules/universal/tests/all-tests.js");
-    require("./node_modules/gpii-windows/tests/UnitTests.js");
-    
     jqUnit.onAllTestsDone.addListener(function (results) {
-    	
     	fluid.log("A total of ", results.total, " tests run, with ", results.failed, " failed tests. Exiting process with status ", results.failed);
-    	
     	process.exit(results.failed); // exits with 0 if no tests failed
     });
 });


### PR DESCRIPTION
Several fixes that make the provisioning process and testing work.
Note that windowsBootstrapURl is now pointing to my GPII-2287 branch of windows and that this needs to be updated once it's merged into windows/hst-2017 (see https://github.com/GPII/windows/pull/111)