### PR TITLE
Full update of gpii-app with the last versions of both windows and universal

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "electron": "1.4.1",
     "request": "2.69.0",
     "infusion": "3.0.0-dev.20170830T182157Z.392b2f8",
-    "gpii-windows": "git://github.com/javihernandez/windows.git#hst-2017+master20170901",
+    "gpii-windows": "git://github.com/GPII/windows.git#hst-2017",
     "node-jqunit": "1.1.7",
     "electron-edge": "6.5.4"
   }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
   "dependencies": {
     "electron": "1.4.1",
     "request": "2.69.0",
-    "infusion": "3.0.0-dev.20170727T125648Z.47055ca",
-    "gpii-windows": "git://github.com/GPII/windows.git#hst-2017",
-    "node-jqunit": "1.1.4"
+    "infusion": "3.0.0-dev.20170830T182157Z.392b2f8",
+    "gpii-windows": "git://github.com/javihernandez/windows.git#hst-2017+master20170901",
+    "node-jqunit": "1.1.7",
+    "electron-edge": "6.5.4"
   }
 }

--- a/provisioning/Installer.ps1
+++ b/provisioning/Installer.ps1
@@ -95,6 +95,10 @@ $msbuild = Get-MSBuild "4.0"
 $listenersDir = Join-Path $stagingWindowsDir "listeners"
 Invoke-Command $msbuild "listeners.sln /nodeReuse:false /p:Platform=Win32 /p:Configuration=Release /p:FrameworkPathOverride=`"C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5.1`"" $listenersDir
 
+Invoke-Environment (Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio 14.0\VS\vcvarsall.bat")
+$proximityListenerDir = Join-Path $stagingWindowsDir "listeners/GPII_ProximityListener"
+Invoke-Command "MSBuild.exe" "GPIIWindowsProximityListener.sln /t:rebuild /nodeReuse:false /p:Configuration=Release /p:Platform=`"Any CPU`"" $proximityListenerDir
+
 md (Join-Path $installerDir "output")
 md (Join-Path $installerDir "temp")
 


### PR DESCRIPTION
Also, this includes:
* updated refs of infusion and node-jqunit
* GPII-2084: Added electron-edge dependency
* GPII-2537: Build the proximity listener before creating installer