### PR TITLE
GPII-2937: Migration to Electron 1.8.4

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
-target=1.8.1
+target=1.8.4
 arch=ia32
 disturl=https://atom.io/download/atom-shell
 runtime=electron

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "license": "BSD-3-Clause",
     "dependencies": {
         "electron": "1.8.4",
-        "electron-edge-js": "8.3.1",
+        "electron-edge-js": "8.3.2",
         "gpii-windows": "0.3.0-dev.20180315T174453Z.02de41c",
         "infusion": "3.0.0-dev.20180222T160835Z.6e1311a",
         "node-jqunit": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     },
     "license": "BSD-3-Clause",
     "dependencies": {
-        "electron": "1.8.1",
+        "electron": "1.8.4",
         "electron-edge-js": "8.3.1",
         "gpii-windows": "0.3.0-dev.20180315T174453Z.02de41c",
         "infusion": "3.0.0-dev.20180222T160835Z.6e1311a",

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -64,6 +64,11 @@ fluid.defaults("gpii.app.menuInApp", {
   * @param events {Object} An object containing the events that may be fired by items in the menu.
   */
 gpii.app.updateMenu = function (tray, menuTemplate, events) {
+    // Needed in order to get around this non graceful check: https://github.com/electron/electron/blob/v1.8.4/lib/browser/api/menu.js#L170
+    // The infusion's expander uses a context different than the current,
+    // which cases this Array check to fail.
+    menuTemplate = gpii.app.recontextualise(menuTemplate);
+
     menuTemplate = gpii.app.menu.expandMenuTemplate(menuTemplate, events);
 
     tray.setContextMenu(Menu.buildFromTemplate(menuTemplate));

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -64,11 +64,10 @@ fluid.defaults("gpii.app.menuInApp", {
   * @param events {Object} An object containing the events that may be fired by items in the menu.
   */
 gpii.app.updateMenu = function (tray, menuTemplate, events) {
+    // XXX Related to: https://github.com/electron/electron/issues/12698
     // Needed in order to get around this non graceful check: https://github.com/electron/electron/blob/v1.8.4/lib/browser/api/menu.js#L170
-    // The infusion's expander uses a context different than the current,
-    // which cases this Array check to fail.
-    menuTemplate = gpii.app.recontextualise(menuTemplate);
-
+    // The infusion's expander applies a different contexts (generated with https://nodejs.org/api/vm.html)
+    // than the current which cases this Array check to fail.
     menuTemplate = gpii.app.menu.expandMenuTemplate(menuTemplate, events);
 
     tray.setContextMenu(Menu.buildFromTemplate(menuTemplate));

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -68,6 +68,8 @@ gpii.app.updateMenu = function (tray, menuTemplate, events) {
     // Needed in order to get around this non graceful check: https://github.com/electron/electron/blob/v1.8.4/lib/browser/api/menu.js#L170
     // The infusion's expander applies a different contexts (generated with https://nodejs.org/api/vm.html)
     // than the current which cases this Array check to fail.
+    menuTemplate = gpii.app.recontextualise(menuTemplate);
+
     menuTemplate = gpii.app.menu.expandMenuTemplate(menuTemplate, events);
 
     tray.setContextMenu(Menu.buildFromTemplate(menuTemplate));

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -157,7 +157,7 @@ gpii.app.timer.clear = function (that) {
  * third party dependencies.
  * Related to: https://github.com/electron/electron/issues/12698
  *
- * @param {Object|Array} object - The object/array that needs to have its contexts fixed
+ * @param {Object|Array} object - The object/array that needs to have its contexts fixed.
  * @returns {Object} The fixed object
  */
 gpii.app.recontextualise = function (object) {
@@ -165,7 +165,7 @@ gpii.app.recontextualise = function (object) {
         return;
     }
     if (fluid.isArrayable(object)) {
-        object.constructor = Array;
+        object = [].slice.call(object);
     }
 
     fluid.each(object, function (value, key) {

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -150,19 +150,31 @@ gpii.app.timer.clear = function (that) {
 };
 
 /**
- * Set proper context (the current) for elements such as arrays.
+ * Set proper context for arrays.
  * This is needed in order for arrays to pass the more strict
- * check of: `instanceof array`. In generally such checks are to be avoided
+ * check of: `instanceof array`. In general such checks are to be avoided
  * in favor of the `fluid.isArray` function, but is useful when dealing with
  * third party dependencies.
+ * Related to: https://github.com/electron/electron/issues/12698
  *
- * @param option {Object} The object/array that needs to have its contexts fixed
+ * @param {Object|Array} object - The object/array that needs to have its contexts fixed
  * @returns {Object} The fixed object
  */
-gpii.app.recontextualise = function (option) {
-    if (fluid.isPlainObject(option)) {
-        // simple approach to restore context of arrays
-        option = JSON.parse(JSON.stringify(option));
+gpii.app.recontextualise = function (object) {
+    if (!fluid.isPlainObject(object)) {
+        return;
     }
-    return option;
+    if (fluid.isArrayable(object)) {
+        object.constructor = Array;
+    }
+
+    fluid.each(object, function (value, key) {
+        if (fluid.isArrayable(object[key])) {
+            // console.log(value);
+            object[key] = [].slice.call(object[key]);
+        }
+        gpii.app.recontextualise(object[key]);
+    });
+
+    return object;
 };

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -148,3 +148,21 @@ gpii.app.timer.clear = function (that) {
         that.timer = null;
     }
 };
+
+/**
+ * Set proper context (the current) for elements such as arrays.
+ * This is needed in order for arrays to pass the more strict
+ * check of: `instanceof array`. In generally such checks are to be avoided
+ * in favor of the `fluid.isArray` function, but is useful when dealing with
+ * third party dependencies.
+ *
+ * @param option {Object} The object/array that needs to have its contexts fixed
+ * @returns {Object} The fixed object
+ */
+gpii.app.recontextualise = function (option) {
+    if (fluid.isPlainObject(option)) {
+        // simple approach to restore context of arrays
+        option = JSON.parse(JSON.stringify(option));
+    }
+    return option;
+};


### PR DESCRIPTION
In order to use Electron 1.8.4, re-contextualizing for the Electron menu template object is needed.
This is caused by a [change](https://github.com/electron/electron/blob/v1.8.4/lib/browser/api/menu.js#L170) in an Array check to a less graceful one.

Infusion expansion uses a different context which causes this check to fail.