### PR TITLE
GPII-3191: Copy the resulting installer into the project folder

### DIFF
--- a/provisioning/Installer.ps1
+++ b/provisioning/Installer.ps1
@@ -93,3 +93,6 @@ Invoke-Environment "C:\Program Files (x86)\Microsoft Visual C++ Build Tools\vcbu
 $setupDir = Join-Path $installerDir "setup"
 $msbuild = Get-MSBuild "4.0"
 Invoke-Command $msbuild "setup.msbuild" $setupDir
+
+# Copy the installer into the c:/vagrant folder
+Invoke-Command "robocopy" "$(Join-Path $installerDir "output") $(Join-Path $projectDir "installer") /job:gpii-app.rcj *.*" $provisioningDir -errorLevel 3


### PR DESCRIPTION
The installer will be copied from the "installer" folder into the
original project folder. For instance, on CI, the installer is being
created under c:/installer and the git project is in c:/vagrant. With
this change the installer will be copied from the c:/installer/output
folder into c:/vagrant/installer.

This allows us to publish the installer as an output build artifact.