### PR TITLE
GPII-3218: Fixed the installer, broken by msbuild extension pack upgrade

### DIFF
--- a/provisioning/Installer.ps1
+++ b/provisioning/Installer.ps1
@@ -14,8 +14,8 @@ $projectDir = (Get-Item $provisioningDir).parent.FullName
 
 Import-Module (Join-Path $provisioningDir 'Provisioning.psm1') -Force
 
-$installerRepo = "https://github.com/GPII/gpii-wix-installer"
-$installerBranch = "HST"
+$installerRepo = "https://github.com/stegru/gpii-wix-installer"
+$installerBranch = "GPII-3218"
 
 # Obtaining useful tools location.
 $installerDir = Join-Path $env:SystemDrive "installer" # a.k.a. C:\installer\


### PR DESCRIPTION
Don't commit this one. This is just a test harness for https://github.com/GPII/gpii-wix-installer/pull/37

