### PR TITLE
GPII-3230: The DPI scaling fixes

### DIFF
--- a/testData/qss/settings.json
+++ b/testData/qss/settings.json
@@ -51,12 +51,12 @@
         "schema": {
             "type": "number",
             "title": "Screen Zoom",
-            "min": 1,
+            "min": -2,
             "max": 2,
-            "divisibleBy": 0.25,
-            "default": 1.25
+            "divisibleBy": 1,
+            "default": 0
         },
-        "value": 1.25,
+        "value": 0,
         "tip": "<div><strong>Zooms everything on the screen</strong></div><div>Amount of Zoom up and down differs by computer.</div>",
         "tooltip": "<div><strong>Change the screen size to make everything larger/smaller.</strong></div><div>Works everywhere.</div>",
         "widget": {

--- a/tests/PreferencesGroupingTests.js
+++ b/tests/PreferencesGroupingTests.js
@@ -84,14 +84,14 @@ var settingGroupsFixture = {
                     }
                 },
                 "http://registry\\.gpii\\.net/common/DPIScale":{
-                    "value":1.25,
+                    "value":1,
                     "schema":{
                         "title":"DPI Scale",
                         "description":"DPI scale factor on default monitor",
                         "type":"number",
-                        "min":1,
-                        "max":2,
-                        "divisibleBy":0.25
+                        "min":-2,
+                        "max":4,
+                        "divisibleBy":1
                     }
                 },
                 "http://registry\\.gpii\\.net/common/cursorSize":{
@@ -184,14 +184,14 @@ jqUnit.test("Group setting tests", function () {
 
     var dpiScaleKey = "http://registry\\.gpii\\.net/common/DPIScale";
     jqUnit.assertLeftHand("The default group contains the DPI scale setting", {
-        value: 1.25,
+        value: 1,
         schema: {
             title: "DPI Scale",
             description: "DPI scale factor on default monitor",
             type: "number",
-            min: 1,
-            max: 2,
-            divisibleBy: 0.25
+            min: -2,
+            max: 4,
+            divisibleBy: 1
         }
     }, defaultGroup.settingControls[dpiScaleKey]);
 


### PR DESCRIPTION
Works with https://github.com/GPII/windows/pull/190 to make the QSS set the correct values.

There's still a problem where the range of the DPI values are dynamic.