### PR TITLE
GPII-3315: Optionally bundling filebeat with gpii installer.

### DIFF
--- a/provisioning/Installer.ps1
+++ b/provisioning/Installer.ps1
@@ -29,6 +29,12 @@ if (Test-Path -Path $installerDir){
 }
 Invoke-Command $git "clone --branch $($installerBranch) $($installerRepo) $($installerDir)"
 
+# Place filebeat inside the installer directory, if it's here.
+$filebeatFile = (Join-Path $provisioningDir 'filebeat.msm')
+if (Test-Path $filebeatFile) {
+    Copy-Item $filebeatFile $installerDir
+}
+
 # If gpii-hst-tools exists delete it and clone it again
 $hstToolsDir = Join-Path (Join-Path $installerDir "staging") "gpii-hst-tools"
 if (Test-Path -Path $hstToolsDir){


### PR DESCRIPTION
This causes the build routine to copy `filebeat.msm`, if it exists, into the installer directory.

See [GPII-3315](https://issues.gpii.net/browse/GPII-3315).