### PR TITLE
GPII-3455: Calling the reset code in the next tick.

### DIFF
--- a/main.js
+++ b/main.js
@@ -38,8 +38,11 @@ var appIsRunning = app.makeSingleInstance(function (commandLine) {
     qssWrapper.qss.show();
 
     if (commandLine.indexOf("--reset") > -1) {
-        var gpiiApp = fluid.queryIoCSelector(fluid.rootComponent, "gpii.app")[0];
-        gpiiApp.resetAllToStandard();
+        process.nextTick(function () {
+            // GPII-3455: Call this in the next tick, to allow electron to free some things.
+            var gpiiApp = fluid.queryIoCSelector(fluid.rootComponent, "gpii.app")[0];
+            gpiiApp.resetAllToStandard();
+        });
     }
 });
 


### PR DESCRIPTION
Fixes this error, when running the "Reset" desktop link while in high-contrast:
```
Reset: Error occurred during logout: Unable to cast COM object of type 'System.__ComObject' to interface type
'System.Management.IWbemServices'. This operation failed because the QueryInterface call on the COM component
for the interface with IID '{9556DC99-828C-11CF-A37E-00AA003240C7}' failed due to the following error: The application
called an interface that was marshalled for a different thread. (Exception from HRESULT: 0x8001010E (RPC_E_WRONG_THREAD)).
```

https://issues.gpii.net/browse/GPII-3455