### PR TITLE
Fix app dependencies

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,5 +31,5 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provision "shell", path: "provisioning/Build.ps1", args: "-originalBuildScriptPath \"C:\\vagrant\\provisioning\\\""
-  # config.vm.provision "shell", path: "provisioning/Installer.ps1", args: "-provisioningDir \"C:\\vagrant\\provisioning\\\""
+  config.vm.provision "shell", path: "provisioning/Installer.ps1", args: "-provisioningDir \"C:\\vagrant\\provisioning\\\""
 end

--- a/main.js
+++ b/main.js
@@ -53,7 +53,9 @@ if (appIsRunning) {
 }
 
 // this module is loaded relatively slow
-require("gpii-universal");
+// it also loads gpii-universal
+require("gpii-windows/index.js");
+
 require("./index.js");
 
 // Close the PSP if there is another instance of it already running.
@@ -70,8 +72,6 @@ fluid.onUncaughtException.addListener(function () {
     // The message should have been already logged anyways
 }, "fail");
 
-
-require("gpii-windows/index.js");
 
 kettle.config.loadConfig({
     configName: kettle.config.getConfigName("app.testing"),

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "infusion": "3.0.0-dev.20180222T160835Z.6e1311a",
         "node-jqunit": "1.1.8",
         "request": "2.88.0",
-        "winstrap": "0.5.12"
+        "winstrap": "0.5.12",
+        "ws": "6.1.2"
     },
     "devDependencies": {
         "electron-packager": "8.5.1",

--- a/tests/IntegrationTests.js
+++ b/tests/IntegrationTests.js
@@ -16,9 +16,9 @@
 
 "use strict";
 
-require("gpii-windows/index.js"); // loads path to gpii-universal
+require("gpii-windows/index.js"); // loads gpii-universal as well
 
-var fluid = fluid.require("%gpii-universal"),
+var fluid = require("infusion"),
     kettle = fluid.registerNamespace("kettle"),
     gpii = fluid.registerNamespace("gpii");
 

--- a/tests/IntegrationTests.js
+++ b/tests/IntegrationTests.js
@@ -16,11 +16,12 @@
 
 "use strict";
 
-var fluid = require("gpii-universal"),
+require("gpii-windows/index.js"); // loads path to gpii-universal
+
+var fluid = fluid.require("%gpii-universal"),
     kettle = fluid.registerNamespace("kettle"),
     gpii = fluid.registerNamespace("gpii");
 
-require("gpii-windows/index.js");
 fluid.require("%gpii-universal/gpii/node_modules/testing");
 
 gpii.loadTestingSupport();


### PR DESCRIPTION
Ensure that `gpii-app` is requiring modules that it explicitly depends on:
- if `gpii-universal` is needed - use `gpii-windows` to load it
- include other missing dependencies - `ws`

Also restore installer creation which was stopped to improve CI tests debugging speed.