### PR TITLE
GPII-3572: Made metrics configurable

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -1,0 +1,8 @@
+# Top-level configs
+
+* [app.production](app.production.json): Production, no metrics.
+* [app.testing](app.testing.json): Testing, no metrics.
+* [app.production.metrics](app.production.metrics.json): Production, with metrics.
+* [app.testing.metrics](app.testing.metrics.json) (*default*): Testing, with metrics.
+* [app.metrics](app.metrics.json): Metrics only.
+* [app.dev](app.dev.json): Development (includes metrics).

--- a/configs/app.dev.json
+++ b/configs/app.dev.json
@@ -14,6 +14,7 @@
         }
     },
     "mergeConfigs": [
-        "%gpii-app/configs/app.base.json"
+        "%gpii-app/configs/app.base.json",
+        "%gpii-app/configs/app.metrics.base.json5"
     ]
 }

--- a/configs/app.metrics.base.json5
+++ b/configs/app.metrics.base.json5
@@ -1,0 +1,15 @@
+// Start the collection of metrics
+{
+    "type": "gpii.appMetricsBase",
+    "options": {
+        "distributeOptions": {
+            "metricsOptions": {
+                "record": {
+                    gradeNames: ["gpii.windowsMetrics", "gpii.metrics.lifecycle"],
+                    logDestination: "tcp://127.0.0.1:51481"
+                },
+                "target": "{that gpii.eventLog}.options"
+            }
+        }
+    }
+}

--- a/configs/app.metrics.json5
+++ b/configs/app.metrics.json5
@@ -1,6 +1,11 @@
+// Start only the metrics capture (no QSS, flowmanager, etc.)
 {
-    "type": "gpii.appMetrics",
+    "type": "gpii.appMetricsOnly",
     "options": {
-        "gradeNames": ["gpii.eventLog", "gpii.metrics.standalone", "gpii.windowsMetrics"],
-    }
+        "gradeNames": ["gpii.eventLog", "gpii.windowsMetrics", "gpii.metrics.standalone"],
+        "logDestination": "tcp://127.0.0.1:51481"
+    },
+    "mergeConfigs": [
+        "%gpii-app/configs/app.metrics.base.json5"
+    ]
 }

--- a/configs/app.metrics.json5
+++ b/configs/app.metrics.json5
@@ -1,0 +1,6 @@
+{
+    "type": "gpii.appMetrics",
+    "options": {
+        "gradeNames": ["gpii.eventLog", "gpii.metrics.standalone", "gpii.windowsMetrics"],
+    }
+}

--- a/configs/app.production.metrics.json5
+++ b/configs/app.production.metrics.json5
@@ -1,0 +1,8 @@
+// Start the app in production, and include metrics.
+{
+    "type": "gpii.appMetrics",
+    "mergeConfigs": [
+        "%gpii-app/configs/app.production.json",
+        "%gpii-app/configs/app.metrics.base.json5"
+    ]
+}

--- a/configs/app.testing.metrics.json5
+++ b/configs/app.testing.metrics.json5
@@ -1,0 +1,8 @@
+// Start the app in testing, and include metrics.
+{
+    "type": "gpii.appMetrics",
+    "mergeConfigs": [
+        "%gpii-app/configs/app.testing.json",
+        "%gpii-app/configs/app.metrics.base.json5"
+    ]
+}

--- a/main.js
+++ b/main.js
@@ -74,6 +74,6 @@ fluid.onUncaughtException.addListener(function () {
 
 
 kettle.config.loadConfig({
-    configName: kettle.config.getConfigName("app.testing"),
+    configName: kettle.config.getConfigName("app.testing.metrics"),
     configPath: kettle.config.getConfigPath("%gpii-app/configs")
 });


### PR DESCRIPTION
Metrics can be turned off, on, or used exclusively.

Configurations are listed in [configs/README.md](https://github.com/stegru/gpii-app/blob/d6d33d6eeb0405d0e1da50b22e8fab35486860e2/configs/README.md).

By default, `app.testing.metrics` is used if no config is specified.

To test: The line `Metrics started` will be logged if metrics have started (set `GPII_EVENT_LOG` to a filename if you want to see the data)

Requires https://github.com/GPII/universal/pull/721.
