### PR TITLE
GPII-3496: Site-config option for auto-login token storage

### DIFF
--- a/siteconfig.json5
+++ b/siteconfig.json5
@@ -74,5 +74,8 @@
     },
 
     // URL to the the place serving the survey triggers data. Note that it should return triggers in JSON format
-    surveyTriggersUrl: "http://survey.gpii.net/survey-triggers.json"
+    surveyTriggersUrl: "http://survey.gpii.net/survey-triggers.json",
+
+    // Store the last login token, and automatically login when morphic is next started.
+    saveLogin: false
 }

--- a/siteconfig.json5
+++ b/siteconfig.json5
@@ -77,5 +77,7 @@
     surveyTriggersUrl: "http://survey.gpii.net/survey-triggers.json",
 
     // Store the last login token, and automatically login when morphic is next started.
+    // Warning: This will cause the user's login token to be stored on the machine. This should be false for shared or
+    // public access computers.
     saveLogin: false
 }

--- a/src/main/siteConfigurationHandler.js
+++ b/src/main/siteConfigurationHandler.js
@@ -95,6 +95,10 @@ fluid.defaults("gpii.app.siteConfigurationHandler", {
         distributeAboutDialogConfig: {
             record: "{that}.options.siteConfig.aboutDialog",
             target: "{app aboutDialog}.options.siteConfig"
+        },
+        distributeSaveLogin: {
+            record: "{that}.options.siteConfig.saveLogin",
+            target: "{/ gpii.userListeners.autoLogin}.options.saveLastLogin"
         }
     }
 });


### PR DESCRIPTION
Used with https://github.com/GPII/universal/pull/725 to provide an option for the storage of the user's token (for auto-login).

