### PR TITLE
GPII-3686: Offset windows to consider windows docked at the top or left

### DIFF
--- a/src/main/common/utils.js
+++ b/src/main/common/utils.js
@@ -78,7 +78,7 @@ gpii.browserWindow.computeWindowPosition = function (width, height, offsetX, off
     offsetX = Math.max(0, (offsetX || 0));
     offsetY = Math.max(0, (offsetY || 0));
 
-    var screenSize = electron.screen.getPrimaryDisplay().workAreaSize;
+    var screenSize = electron.screen.getPrimaryDisplay().workArea;
 
     // position relatively to the bottom right corner
     // note that as offset is positive we're restricting window
@@ -90,8 +90,10 @@ gpii.browserWindow.computeWindowPosition = function (width, height, offsetX, off
     desiredY = Math.max(desiredY, 0);
 
     return {
-        x: desiredX,
-        y: desiredY
+        // Offset it to factor in the start of the work area, which takes into account docked windows like magnifier and
+        // Read&Write.
+        x: desiredX + screenSize.x,
+        y: desiredY + screenSize.y
     };
 };
 


### PR DESCRIPTION
When Read&Write gold is docked at the top, the QSS is positioned incorrectly.

This PR fixes it (I've only tested with magnifier)

![QSS position](https://issues.gpii.net/secure/attachment/21500/Unfolded.png)