### PR TITLE
GPII-3521: QuickStrip is not fully visible on the screen

### DIFF
--- a/src/main/dialogs/quickSetStrip/qssDialog.js
+++ b/src/main/dialogs/quickSetStrip/qssDialog.js
@@ -36,7 +36,7 @@ fluid.defaults("gpii.app.qss", {
         logoWidth: 117,
         // The width of a single button together with its left margin
         buttonWidth: 59,
-        closeButtonWidth: 24
+        closeButtonWidth: 29
     },
     qssButtonTypes: {
         smallButton: "smallButton",


### PR DESCRIPTION
Added missing margin to the close button width, which solves the low-resolution issue.