### PR TITLE
GPII-3777: Quick Folders (via URL)

### DIFF
--- a/messageBundles/gpii-app-qss-settings_bg.json
+++ b/messageBundles/gpii-app-qss-settings_bg.json
@@ -56,5 +56,9 @@
         "tooltip": "<p>Change Windows language setting.</p><p>Works for menus, etc. in Windows, Edge, and many other applications that have Language Packs installed.</p>",
         "title": "Език",
         "tip": "<p>Changes Language of Windows</p><p>Works in Windows and programs that support Windows language settings.</p><ul><li>Does not change the language in documents or files.</li><li>May need to restart some programs.</li></ul>"
+    },
+    "gpii_app_qss_settings_cloud-folder-open": {
+        "tooltip": "<p>Отваря cloud базирана публична папка.</p>",
+        "title": "Quick Folders"
     }
 }

--- a/messageBundles/gpii-app-qss-settings_en.json
+++ b/messageBundles/gpii-app-qss-settings_en.json
@@ -66,5 +66,9 @@
         "tooltip": "<p>Change Windows language setting.</p><p>Works for menus, etc. in Windows, Edge, and many other applications that have Language Packs installed.</p>",
         "title": "Language",
         "tip": "<p>Changes Language of Windows</p><p>Works in Windows and programs that support Windows language settings.</p><ul><li>Does not change the language in documents or files.</li><li>May need to restart some programs.</li></ul>"
+    },
+    "gpii_app_qss_settings_cloud-folder-open": {
+        "tooltip": "<p>A quick way to find a common packages of documents, web pages, or other resources.</p>",
+        "title": "Quick Folders"
     }
 }

--- a/siteconfig.json5
+++ b/siteconfig.json5
@@ -11,7 +11,8 @@
         // The scaling factor for the QSS
         scaleFactor: 1.5,
         urls: {
-            account: "http://morphic.world/account"
+            account: "http://morphic.world/account",
+            cloudFolder: "https://1drv.ms/f/s!AgsFNSfCYeO3glLjXGakJRG3irEc"
         },
 
         // The template that is used for every label of the language setting's options.
@@ -32,7 +33,6 @@
         messages: {
             keyedOut: "To save your settings you need to setup a Morphic Account. Go to <a href=\"http://morphic.world/account\">http://morphic.world/account</a>."
         }
-
     },
 
     // Configuration options for the PSP window

--- a/src/main/dialogs/quickSetStrip/qssDialog.js
+++ b/src/main/dialogs/quickSetStrip/qssDialog.js
@@ -77,7 +77,8 @@ fluid.defaults("gpii.app.qss", {
             transparent: false
         },
         params: {
-            settings: "{that}.model.settings"
+            settings: "{that}.model.settings",
+            siteConfig: "{that}.options.siteConfig"
         },
         fileSuffixPath: "qss/index.html"
     },

--- a/src/main/qss.js
+++ b/src/main/qss.js
@@ -858,9 +858,10 @@ fluid.defaults("gpii.app.qssInWrapper", {
     },
     config: {
         params: {
-            settings: "{qssWrapper}.model.settings"
+            settings: "{qssWrapper}.model.settings",
         }
     },
+    siteConfig: "{qssWrapper}.options.siteConfig",
     pspButtonPath: "psp",
     events: {
         onQssPspClose: "{qssWrapper}.events.onQssPspClose",

--- a/src/main/qss.js
+++ b/src/main/qss.js
@@ -858,7 +858,7 @@ fluid.defaults("gpii.app.qssInWrapper", {
     },
     config: {
         params: {
-            settings: "{qssWrapper}.model.settings",
+            settings: "{qssWrapper}.model.settings"
         }
     },
     siteConfig: "{qssWrapper}.options.siteConfig",

--- a/src/main/siteConfigurationHandler.js
+++ b/src/main/siteConfigurationHandler.js
@@ -52,6 +52,10 @@ fluid.defaults("gpii.app.siteConfigurationHandler", {
             record: "{that}.options.siteConfig.qss",
             target: "{app qssWrapper}.options.siteConfig"
         },
+        distributeQssWidgetConfig: {
+            record: "{that}.options.siteConfig.qss",
+            target: "{app qssWidget}.options.config.params.siteConfig"
+        },
         distributeLanguageLabelTemplate: {
             record: "{that}.options.siteConfig.qss.languageOptionLabel",
             target: "{app qssWrapper}.options.settingOptions.languageOptionLabelTemplate"

--- a/src/renderer/qss/js/index.js
+++ b/src/renderer/qss/js/index.js
@@ -24,7 +24,8 @@
         gpii.psp.translatedQss(".flc-quickSetStrip", {
             model: {
                 settings: windowInitialParams.settings
-            }
+            },
+            siteConfig: windowInitialParams.siteConfig
         });
     });
 })(fluid);

--- a/src/renderer/qss/js/qss.js
+++ b/src/renderer/qss/js/qss.js
@@ -117,7 +117,8 @@
                 options: {
                     model: {
                         settings: "{translatedQss}.model.settings"
-                    }
+                    },
+                    siteConfig: "{translatedQss}.options.siteConfig"
                 }
             }
         }

--- a/src/renderer/qss/js/qss.js
+++ b/src/renderer/qss/js/qss.js
@@ -39,6 +39,7 @@
             "undo":     "gpii.qss.undoButtonPresenter",
             "resetAll": "gpii.qss.resetAllButtonPresenter",
             "more":     "gpii.qss.moreButtonPresenter",
+            "cloud-folder-open": "gpii.qss.openCloudFolderPresenter",
             "disabled": "gpii.qss.disabledButtonPresenter"
         },
 

--- a/src/renderer/qss/js/qssServiceButtons.js
+++ b/src/renderer/qss/js/qssServiceButtons.js
@@ -260,20 +260,26 @@
         invokers: {
             activate: {
                 funcName: "gpii.qss.openCloudFolderPresenter.activate",
-                args: []
+                args: ["{gpii.qss}.options.siteConfig.urls.cloudFolder"] // siteConfig's cloud folder url
             }
         }
     });
 
     /**
      * A custom function for handling activation of the "Quick Folders" QSS button.
+     * opens a provided url in the default browser using electron's shell
+     * @param {String} cloudFolderUrl - cloud folder's url
      */
-    gpii.qss.openCloudFolderPresenter.activate = function () {
+    gpii.qss.openCloudFolderPresenter.activate = function (cloudFolderUrl) {
         const {shell} = require('electron');
-        let url = 'https://github.com';
 
-        console.log('==== openCloudFolderPresenter: '+url);
-        shell.openExternal(url);
+        if (fluid.isValue(cloudFolderUrl)) {
+            // we have the url, opening it in the default browser
+            shell.openExternal(cloudFolderUrl);
+        } else {
+            // there is no value in the config, sending the warning
+            fluid.log(fluid.logLevel.WARN, "Service Buttons (openCloudFolderPresenter): Cannot find a proper url path [siteConfig.qss.urlscloudFolder]");
+        }
     };
 
 })(fluid);

--- a/src/renderer/qss/js/qssServiceButtons.js
+++ b/src/renderer/qss/js/qssServiceButtons.js
@@ -250,4 +250,30 @@
         that.notifyButtonActivated(activationParams);
         qssList.events.onResetAllRequired.fire();
     };
+
+    /**
+     * Inherits from `gpii.qss.buttonPresenter` and handles interactions with the "Open USB Button"
+     * QSS button.
+     */
+    fluid.defaults("gpii.qss.openCloudFolderPresenter", {
+        gradeNames: ["gpii.qss.buttonPresenter"],
+        invokers: {
+            activate: {
+                funcName: "gpii.qss.openCloudFolderPresenter.activate",
+                args: []
+            }
+        }
+    });
+
+    /**
+     * A custom function for handling activation of the "Quick Folders" QSS button.
+     */
+    gpii.qss.openCloudFolderPresenter.activate = function () {
+        const {shell} = require('electron');
+        let url = 'https://github.com';
+
+        console.log('==== openCloudFolderPresenter: '+url);
+        shell.openExternal(url);
+    };
+
 })(fluid);

--- a/src/renderer/qssWidget/js/qssWidget.js
+++ b/src/renderer/qssWidget/js/qssWidget.js
@@ -112,6 +112,7 @@
                 },
                 options: {
                     sounds: "{qssWidget}.options.sounds",
+                    siteConfig: "{qssWidget}.options.siteConfig",
                     activationParams: "{arguments}.1",
                     model: {
                         setting: "{qssWidget}.model.setting",

--- a/testData/qss/settings.json
+++ b/testData/qss/settings.json
@@ -1,5 +1,14 @@
 [
     {
+        "path": "cloud-folder-open",
+        "schema": {
+            "type": "cloud-folder-open"
+        },
+        "buttonTypes": ["largeButton", "settingButton"],
+        "tabindex": 0,
+        "messageKey": "cloud-folder-open"
+    },
+    {
         "path": "http://registry\\.gpii\\.net/common/language",
         "schema": {
             "type": "string",

--- a/tests/QssTestDefs.js
+++ b/tests/QssTestDefs.js
@@ -35,6 +35,9 @@ function clickStepperIndicator() {
     jQuery(".fl-qssStepperWidget-indicator:nth-of-type(3)").click();
 }
 
+function getQuickFolderWIdgetBtnText() {
+    return jQuery(".flc-quickSetStrip > div:nth-last-of-type(7) > span").text();
+}
 
 
 // QSS related
@@ -58,6 +61,7 @@ var hoverCloseBtn = "jQuery(\".flc-quickSetStrip > div:last-of-type\").trigger(\
 // QSS Widgets related
 var checkIfMenuWidget = "jQuery('.flc-qssMenuWidget').is(':visible');",
     checkIfStepperWidget = "jQuery('.flc-qssStepperWidget').is(':visible');",
+    checkIfQuickFoldersWidget = "jQuery('.flc-quickSetStrip > div:nth-last-of-type(7)').is(':visible')",
     clickMenuWidgetItem = "jQuery('.flc-qssWidgetMenu-item:nth-of-type(2)').click()",
     clickIncreaseBtn = "jQuery('.flc-qssStepperWidget-incBtn').click()",
     clickDecreaseBtn = "jQuery('.flc-qssStepperWidget-decBtn').click()",
@@ -152,7 +156,7 @@ gpii.tests.qss.clearFocusedElement = function () {
     jQuery(".fl-qss-button").removeClass("fl-focused fl-highlighted");
 };
 
-var qssSettingsCount = 11;
+var qssSettingsCount = 12;
 
 var navigationSequence = [
     {
@@ -1318,6 +1322,39 @@ var appZoomTestSequence = [
     }
 ];
 
+var quickFoldersTestSequence = [
+    { // Open the QSS...
+        func: "{that}.app.tray.events.onTrayIconClicked.fire"
+    }, { // ... and quick folders button should be visible
+        task: "gpii.test.executeJavaScriptInWebContents",
+        args: [
+            "{that}.app.qssWrapper.qss.dialog",
+            checkIfQuickFoldersWidget
+        ],
+        resolve: "jqUnit.assertTrue",
+        resolveArgs: ["The quick folder button is displayed: ", "{arguments}.0"]
+    }, { // Text of the button should be
+        task: "gpii.test.invokeFunctionInWebContents",
+        args: [
+            "{that}.app.qssWrapper.qss.dialog",
+            getQuickFolderWIdgetBtnText
+        ],
+        resolve: "jqUnit.assertEquals",
+        resolveArgs: [
+            "Text of the button should be",
+            "Quick Folders",
+            "{arguments}.0"
+        ]
+    }, { // Close the QSS
+        task: "gpii.test.executeJavaScriptInWebContents",
+        args: [
+            "{that}.app.qssWrapper.qss.dialog",
+            clickCloseBtn
+        ],
+        resolve: "fluid.identity"
+    }
+];
+
 fluid.defaults("gpii.tests.qss.mockedAppZoom", {
     gradeNames: "fluid.component",
 
@@ -1608,7 +1645,7 @@ var qssInstalledLanguages = [
 
 gpii.tests.qss.testDefs = {
     name: "QSS Widget integration tests",
-    expect: 84,
+    expect: 86,
     config: {
         configName: "gpii.tests.dev.config",
         configPath: "tests/configs"
@@ -1652,6 +1689,7 @@ gpii.tests.qss.testDefs = {
         qssInstalledLanguages,
         undoCrossTestSequence,
         undoTestSequence,
+        quickFoldersTestSequence,
         qssCrossTestSequence,
         stepperindicatorsSequence,
         crossQssTranslations,

--- a/tests/fixtures/qssSettings.json
+++ b/tests/fixtures/qssSettings.json
@@ -26,7 +26,7 @@
             "default": "en-US"
         },
         "buttonTypes": ["largeButton", "settingButton"],
-        "tabindex": 1,
+        "tabindex": 10,
         "messageKey": "common-language",
         "learnMoreLink": "https://morphic.world/help/qsshelp#language",
         "value": "en-US",
@@ -44,7 +44,7 @@
             "default": 0
         },
         "buttonTypes": ["largeButton", "settingButton"],
-        "tabindex": 2,
+        "tabindex": 20,
         "messageKey": "common-DPIScale",
         "value": 0,
         "tip": "<p>Zooms everything on the screen</p><p>Amount of Zoom up and down differs by computer.</p>",
@@ -63,7 +63,7 @@
             "divisibleBy": 1
         },
         "buttonTypes": ["largeButton", "settingButton"],
-        "tabindex": 3,
+        "tabindex": 30,
         "messageKey": "appTextZoom",
         "value": 0,
         "tip": "<p>Zooms one application.</p><p>Works in many applications</p><p>-- for the Window on top.</p><p>(Not a setting so won't Save.)</p>",
@@ -100,7 +100,7 @@
             "default": "regular-contrast"
         },
         "buttonTypes": ["largeButton", "settingButton"],
-        "tabindex": 4,
+        "tabindex": 40,
         "messageKey": "common-highContrastTheme",
         "value": "regular-contrast",
         "styles": {
@@ -158,11 +158,19 @@
             "default": false
         },
         "buttonTypes": ["largeButton", "settingButton"],
-        "tabindex": 5,
+        "tabindex": 50,
         "messageKey": "common-selfVoicing-enabled",
         "value": false,
         "learnMoreLink": "https://morphic.world/basics/learn-more-about-quickstrip#readaloud",
         "tooltip": "<p>Turn “Select to Read Aloud” extension in Chrome browser on/off.</p>"
+    }, {
+        "path": "cloud-folder-open",
+        "schema": {
+            "type": "cloud-folder-open"
+        },
+        "buttonTypes": ["largeButton", "settingButton"],
+        "tabindex": 180,
+        "messageKey": "cloud-folder-open"
     }, {
         "path": "more",
         "schema": {
@@ -170,7 +178,7 @@
             "title": "MORE...\n\n(& HELP)"
         },
         "buttonTypes": ["largeButton"],
-        "tabindex": 6,
+        "tabindex": 200,
         "messageKey": "more",
         "tooltip": "<p>More options for changing the settings on this computer.</p>"
     }, {
@@ -180,7 +188,7 @@
             "title": "Save"
         },
         "buttonTypes": ["smallButton"],
-        "tabindex": 7,
+        "tabindex": 210,
         "messageKey": "save",
         "tooltip": "<p>Save your preferences so you can use them on other computers that have Morphic installed.</p>"
     }, {
@@ -190,7 +198,7 @@
             "title": "Undo"
         },
         "buttonTypes": ["smallButton"],
-        "tabindex": 9,
+        "tabindex": 220,
         "messageKey": "undo",
         "tooltip": "<p>Undo the last change you made in the Morphic QuickStrip.</p>"
     }, {
@@ -203,7 +211,7 @@
             }
         },
         "buttonTypes": ["smallButton"],
-        "tabindex": 8,
+        "tabindex": 230,
         "messageKey": "psp",
         "tooltip": {
             "keyedIn": "<p>Opens Morphic Settings Panel</p><p>Where you can quickly adjust often-changed settings of yours.</p>",
@@ -216,7 +224,7 @@
             "title": "Reset to Standard"
         },
         "buttonTypes": ["smallButton"],
-        "tabindex": 10,
+        "tabindex": 240,
         "messageKey": "resetAll",
         "tooltip": "<p>Resets computer to standard settings</p><p>(does not affect personal saved settings)</p>"
     }, {
@@ -226,7 +234,7 @@
             "title": "×"
         },
         "buttonTypes": ["closeButton"],
-        "tabindex": 11,
+        "tabindex": 250,
         "messageKey": "close",
         "tooltip": "<p>Close Morphic QuickStrip</p><p>You can reopen it using the Morphic Icon (below) <img height=12 src='../../icons/TaskTrayIcon_outline.svg'></img></p>"
     }


### PR DESCRIPTION
* Created a new service button called **"Quick Folders"** for access to the quick cloud folder.
* Added all the required changes in order to be able to use **siteConfig** in all of the widgets _(this will be reused in any other button that needs siteConfig)_