### PR TITLE
GPII-3788: Rename the "Learn More" links in the widget popups

### DIFF
--- a/messageBundles/gpii-app-messageBundle_en.json
+++ b/messageBundles/gpii-app-messageBundle_en.json
@@ -68,7 +68,7 @@
         "keyedIn": "Your settings were saved to the Morphic Cloud."
     },
 
-    "gpii_psp_qssWidget_learnMore": "Learn more...",
+    "gpii_psp_qssWidget_learnMore": "Help / Learn more",
 
     "gpii_qssWidget_stepper_incrementButton": "Larger",
     "gpii_qssWidget_stepper_decrementButton": "Smaller",


### PR DESCRIPTION
* Renamed the "Learn More..." links to "Help / Learn more"