### PR TITLE
GPII-3797: "Quick Folders" should be "Open Quick Folder"

### DIFF
--- a/messageBundles/gpii-app-qss-settings_en.json
+++ b/messageBundles/gpii-app-qss-settings_en.json
@@ -80,6 +80,6 @@
     },
     "gpii_app_qss_settings_cloud-folder-open": {
         "tooltip": "<p>A quick way to find a common packages of documents, web pages, or other resources.</p>",
-        "title": "Quick Folders"
+        "title": "Open Quick Folder"
     }
 }

--- a/messageBundles/gpii-app-qss-settings_en.json
+++ b/messageBundles/gpii-app-qss-settings_en.json
@@ -79,7 +79,7 @@
         ]
     },
     "gpii_app_qss_settings_cloud-folder-open": {
-        "tooltip": "<p>A quick way to find common packages of documents, web pages, or other resources.</p>",
+        "tooltip": "<p>The Quick Folder has commonly requested documents, web pages, and other resources.</p>",
         "title": "Open Quick Folder"
     }
 }

--- a/tests/QssTestDefs.js
+++ b/tests/QssTestDefs.js
@@ -1371,7 +1371,7 @@ var quickFoldersTestSequence = [
         resolve: "jqUnit.assertEquals",
         resolveArgs: [
             "Text of the button should be",
-            "Quick Folders",
+            "Open Quick Folder",
             "{arguments}.0"
         ]
     }, { // Close the QSS


### PR DESCRIPTION
* Quick Folder's button name changed