### PR TITLE
GPII-3789: Optionally include sharex merge module into the installer

### DIFF
--- a/provisioning/Installer.ps1
+++ b/provisioning/Installer.ps1
@@ -14,8 +14,8 @@ $projectDir = (Get-Item $provisioningDir).parent.FullName
 
 Import-Module (Join-Path $provisioningDir 'Provisioning.psm1') -Force
 
-$installerRepo = "https://github.com/GPII/gpii-wix-installer"
-$installerBranch = "HST"
+$installerRepo = "https://github.com/javihernandez/gpii-wix-installer"
+$installerBranch = "GPII-3789.master"
 
 # Obtaining useful tools location.
 $installerDir = Join-Path $env:SystemDrive "installer" # a.k.a. C:\installer\
@@ -47,6 +47,12 @@ Invoke-Command $git "clone --branch $($installerBranch) $($installerRepo) $($ins
 $filebeatFile = (Join-Path $provisioningDir 'filebeat.msm')
 if (Test-Path $filebeatFile) {
     Copy-Item $filebeatFile $installerDir
+}
+
+# Place sharex inside the installer directory, if it's here.
+$sharexFile = (Join-Path $provisioningDir 'sharex.msm')
+if (Test-Path $sharexFile) {
+    Copy-Item $sharexFile $installerDir
 }
 
 # Create staging folder

--- a/siteconfig.json5
+++ b/siteconfig.json5
@@ -35,7 +35,7 @@
         },
 
         // the path to the ShareX's executable file, used in the screenCaptureWidget
-        shareXPath: "C:\\Program Files (x86)\\Morphic\\windows\\resources\\sharex-portable\\sharex.exe"
+        shareXPath: "C:\\Program Files (x86)\\Morphic\\sharex\\sharex-portable\\sharex.exe"
     },
 
     // Configuration options for the PSP window


### PR DESCRIPTION
Still need to finish up the sharex-merge-module git repo to generate the .msm file.
If we need to test this before I'm done with that repo, feel free to ask me for the sharex.msm file that we included in the last installer.

Works with https://github.com/GPII/gpii-wix-installer/pull/59