### PR TITLE
GPII-3872: Add siteConfig option for QSS open on startup

### DIFF
--- a/siteconfig.json5
+++ b/siteconfig.json5
@@ -5,6 +5,9 @@
 
     // Configuration options for the QSS window
     qss: {
+        // Determines if the QSS will be shown automatically on Morphic's startup
+        showQssOnStart: true,
+
         // Defines the delay in milliseconds before the tooltip is shown after a QSS button is selected
         tooltipDisplayDelay: 500, // ms
 

--- a/src/main/qss.js
+++ b/src/main/qss.js
@@ -141,6 +141,10 @@ fluid.defaults("gpii.app.qssWrapper", {
                 "{gpii.app.qss}",
                 "{arguments}.0"
             ]
+        },
+        "onCreate": {
+            funcName: "gpii.app.qssWrapper.showQssOnStart",
+            args: ["{that}.options.siteConfig.showQssOnStart", "{gpii.app.qss}"]
         }
     },
 
@@ -844,6 +848,18 @@ gpii.app.qssWrapper.showTooltipIfPossible = function (qssWrapper, qssTooltip, se
     }
 };
 
+/**
+ * Shows the QSS if the flag is set to true
+ * @param {Boolean} showQssOnStart - true/false flag
+ * @param {Component} qss - The `gpii.app.qssDialog` instance
+ */
+gpii.app.qssWrapper.showQssOnStart = function (showQssOnStart, qss) {
+    // auto-show the QSS only if the flag is set to true
+    if (showQssOnStart) {
+        // showing it
+        qss.show();
+    }
+};
 
 /**
  * Configuration for using the `gpii.app.qss` in the QSS wrapper component.


### PR DESCRIPTION
Added option to show QSS on startup:
* Added new siteConfig value called showQssOnStart (boolean)
* Using set value to determine to show QSS or not on Morphic's startup