### PR TITLE
GPII-3884: QSS High Contrast menu misspell fix

### DIFF
--- a/messageBundles/gpii-app-qss-settings_en.json
+++ b/messageBundles/gpii-app-qss-settings_en.json
@@ -45,7 +45,7 @@
             "White on black",
             "Yellow on black",
             "Black on yellow",
-            "Grey on white",
+            "Gray on white",
             "Black on brown"
         ]
     },


### PR DESCRIPTION
* Fixed the word "Grey" to "Gray" in the High Contrast menu