### PR TITLE
GPII-4028: Option to use chrome instead of default browser, for quick docs

### DIFF
--- a/siteconfig.json5
+++ b/siteconfig.json5
@@ -18,7 +18,7 @@
             cloudFolder: "https://docs.google.com/document/d/1gOi5JXw30lyD5DGbwe6tme_MfEyaiDz95AQSrzPNfZU/"
         },
 
-        alwaysUseChrome: true,
+        alwaysUseChrome: false,
 
         // The template that is used for every label of the language setting's options.
         // The "%" followed by a word specifies a variable and there are three possible variables:

--- a/siteconfig.json5
+++ b/siteconfig.json5
@@ -72,7 +72,7 @@
     },
 
     // Whether to hide the QSS when a user clicks outside of it
-    closeQssOnClickOutside: false,
+    closeQssOnClickOutside: true,
 
     // Whether to disable the displaying of notifications that suggest some
     // applications may need to be restarted in order for a changed setting to be
@@ -81,7 +81,7 @@
     disableRestartWarning: false,
 
     // Whether to hide the PSP when a user clicks outside of it
-    closePspOnClickOutside: false,
+    closePspOnClickOutside: true,
 
     // The shortcut that open the QSS. For posible values refer to: https://electronjs.org/docs/api/accelerator
     openQssShortcut: "Shift+CmdOrCtrl+Alt+Super+M",

--- a/siteconfig.json5
+++ b/siteconfig.json5
@@ -18,6 +18,8 @@
             cloudFolder: "https://docs.google.com/document/d/1gOi5JXw30lyD5DGbwe6tme_MfEyaiDz95AQSrzPNfZU/"
         },
 
+        alwaysUseChrome: true,
+
         // The template that is used for every label of the language setting's options.
         // The "%" followed by a word specifies a variable and there are three possible variables:
         // - native - the name of the language in its native form
@@ -70,7 +72,7 @@
     },
 
     // Whether to hide the QSS when a user clicks outside of it
-    closeQssOnClickOutside: true,
+    closeQssOnClickOutside: false,
 
     // Whether to disable the displaying of notifications that suggest some
     // applications may need to be restarted in order for a changed setting to be
@@ -79,7 +81,7 @@
     disableRestartWarning: false,
 
     // Whether to hide the PSP when a user clicks outside of it
-    closePspOnClickOutside: true,
+    closePspOnClickOutside: false,
 
     // The shortcut that open the QSS. For posible values refer to: https://electronjs.org/docs/api/accelerator
     openQssShortcut: "Shift+CmdOrCtrl+Alt+Super+M",

--- a/src/renderer/qss/js/qssServiceButtons.js
+++ b/src/renderer/qss/js/qssServiceButtons.js
@@ -282,7 +282,10 @@
         invokers: {
             activate: {
                 funcName: "gpii.qss.openCloudFolderPresenter.activate",
-                args: ["{gpii.qss}.options.siteConfig.urls.cloudFolder"] // siteConfig's cloud folder url
+                args: [
+                    "{gpii.qss}.options.siteConfig.urls.cloudFolder",  // siteConfig's cloud folder url
+                    "{gpii.qss}.options.siteConfig.alwaysUseChrome" // Override the OS default browser.
+                ]
             }
         }
     });
@@ -291,17 +294,34 @@
      * A custom function for handling activation of the "Quick Folders" QSS button.
      * opens a provided url in the default browser using electron's shell
      * @param {String} cloudFolderUrl - cloud folder's url
+     * @param {Boolean} alwaysUseChrome - true to use chrome, rather than the default browser.
      */
-    gpii.qss.openCloudFolderPresenter.activate = function (cloudFolderUrl) {
+    gpii.qss.openCloudFolderPresenter.activate = function (cloudFolderUrl, alwaysUseChrome) {
         var shell = require("electron").shell;
 
         if (fluid.isValue(cloudFolderUrl)) {
-            // we have the url, opening it in the default browser
-            shell.openExternal(cloudFolderUrl);
+            if (alwaysUseChrome) {
+                var child_process = require("child_process");
+                var command =
+                    // Check chrome is installed
+                    "reg query \"HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.exe\" /ve"
+                    // If so, run chrome
+                    + " && start chrome \"" + cloudFolderUrl.replace(/"/g, "%22") + "\"";
+                child_process.exec(command, function (err) {
+                    if (err) {
+                        // It failed, so use the default browser.
+                        shell.openExternal(cloudFolderUrl);
+                    }
+                });
+            } else {
+                // we have the url, opening it in the default browser
+                shell.openExternal(cloudFolderUrl);
+            }
         } else {
             // there is no value in the config, sending the warning
             fluid.log(fluid.logLevel.WARN, "Service Buttons (openCloudFolderPresenter): Cannot find a proper url path [siteConfig.qss.urlscloudFolder]");
         }
+
     };
 
 })(fluid);


### PR DESCRIPTION
Override the user's preferred browser for the quick docs link in the QS.

(optimised for implementation speed, rather than engineering brilliance)