### PR TITLE
GPII-4189, GPII-4190, GPII-4191: My Google Drive, My One Drive, and My Dropbox

### DIFF
--- a/messageBundles/gpii-app-qss-settings_bg.json
+++ b/messageBundles/gpii-app-qss-settings_bg.json
@@ -92,5 +92,17 @@
     "gpii_app_qss_settings_launch-documorph": {
         "tooltip": "<p>Стартирай апликацията DocuMorph.</p>",
         "title": "Стартирай Docu Morph"
+    },
+    "gpii_app_qss_settings_url-google-drive": {
+        "tooltip": "<p>Отваря Google Drive във браузъра.</p>",
+        "title": "Моят Google Drive"
+    },
+    "gpii_app_qss_settings_url-one-drive": {
+        "tooltip": "<p>Отваря One Drive във браузъра.</p>",
+        "title": "Моят One Drive"
+    },
+    "gpii_app_qss_settings_url-dropbox": {
+        "tooltip": "<p>Отваря Dropbox във браузъра.</p>",
+        "title": "Моят Dropbox"
     }
 }

--- a/messageBundles/gpii-app-qss-settings_en.json
+++ b/messageBundles/gpii-app-qss-settings_en.json
@@ -105,5 +105,17 @@
         "tooltip": "<p>Tools to translate text, documents, web pages, or live speech.</p>",
         "title": "Translate Tools",
         "tip": "<p>Translate Tools</p>To translate <b>text, documents, web pages</b> or <b>live speech</b>, try one of the following free services or apps.<br /><br /><i>Links are for convenience. No endorsement or privacy guarantee.</i><br /><br /><b>Microsoft Word 365</b> has a Translator in its <b>Review</b> ribbon<br /><br /><b>Web based & Apps</b><br /><ul><li><a href='https://translate.google.com/' class=\"fl-focusable\">Google</a>  - <b>Web, Text, Docs</b></li><li><a href='https://www.bing.com/translator' class=\"fl-focusable\">Microsoft Bing</a>  - <b>Web, Text</b></li><li><a href='http://www.online-translator.com/' class=\"fl-focusable\">PROMT</a>  - <b>Web</b></li><li><a href='http://www.reverso.net/text_translation.aspx' class=\"fl-focusable\">Reverso</a>  - <b>Web</b></li><li><a href='https://www.translatelive.com/' class=\"fl-focusable\">Translate Live</a>  - <b>Live Speech</b></li><li><a href='https://www.microsoft.com/en-us/translator/' class=\"fl-focusable\">Microsoft Translator APP</a>  - <b>Web, Text, Live Speech, StreetSigns</b></li></ul><br /><b>NOTE:</b> There are also plug-ins and built-in translation features for different browsers."
+    },
+    "gpii_app_qss_settings_url-google-drive": {
+        "tooltip": "<p>Opens Google Drive in the browser.</p>",
+        "title": "My Google Drive"
+    },
+    "gpii_app_qss_settings_url-one-drive": {
+        "tooltip": "<p>Opens One Drive in the browser.</p>",
+        "title": "My One Drive"
+    },
+    "gpii_app_qss_settings_url-dropbox": {
+        "tooltip": "<p>Opens Dropbox in the browser.</p>",
+        "title": "My Dropbox"
     }
 }

--- a/siteconfig.json5
+++ b/siteconfig.json5
@@ -15,7 +15,10 @@
         scaleFactor: 1.2,
         urls: {
             account: "http://morphic.world/account",
-            cloudFolder: "https://drive.google.com/drive/folders/11m-AKdP-0wjEBocpVtvnK8iE23P7hFTS"
+            cloudFolder: "https://drive.google.com/drive/folders/11m-AKdP-0wjEBocpVtvnK8iE23P7hFTS",
+            myGoogleDrive: "https://drive.google.com/",
+            myOneDrive: "https://onedrive.live.com/about/signin/",
+            myDropbox: "https://www.dropbox.com/login"
         },
 
         alwaysUseChrome: false,
@@ -45,7 +48,7 @@
 
         // list of the desired list of buttons shown in QSS
         // it uses the `id` attribute found in settings.json items
-        // 
+        //
         // Custom buttons: Instead of a string with buttonId you add an object with the custom button data like this:
         // {
         //      "buttonId": "MakeYourOwn",
@@ -56,11 +59,10 @@
         //      "popupText": "<p>Launch the Notepad application.</p>", // tooltip text
         //      "description": "The full description of the button..." // optional description
         // }
-        // 
+        //
         // Separator buttons: Use can use any combination of the separators, even one after another:
         // "separator" // Use separator for invisible separator
         // "separator-visible" // Use separator-visible for a gray separator (same size as the invisible one)
-         
         buttonList: [
             {
                 "buttonId": "MakeYourOwn",
@@ -92,6 +94,10 @@
             "launch-documorph",
             "cloud-folder-open",
             "usb-open",
+            "separator",
+            "url-google-drive",
+            "url-one-drive",
+            "url-dropbox",
             "separator-visible",
             "service-more",
             "service-save",

--- a/src/main/app.js
+++ b/src/main/app.js
@@ -440,9 +440,9 @@ fluid.defaults("gpii.app", {
 
 /**
  * Get the Gpii key name of the last environmental login.
+ * @param {String} lastEnvironmentalLoginGpiiKey - Gpii key name of the last environmental login.
  * @param {Object} browserWindow - An Electron `BrowserWindow` object.
  * @param {String} messageChannel - The channel to which the message should be sent.
- * @param {String} lastEnvironmentalLoginGpiiKey - Gpii key name of the last environmental login.
  */
 gpii.app.getEnvironmentalLoginKey = function (lastEnvironmentalLoginGpiiKey, browserWindow, messageChannel) {
     gpii.app.notifyWindow(browserWindow, messageChannel, lastEnvironmentalLoginGpiiKey);

--- a/src/main/dialogs/basic/dialog.js
+++ b/src/main/dialogs/basic/dialog.js
@@ -553,7 +553,7 @@ gpii.app.dialog.setBounds = function (that, restrictions, width, height, offsetX
     // Because restriction of the minimum height, widgets with little content will have large empty spaces.
     // This is a temporary solution for the "My saved settings" till the widget is filling with more content.
     if (that.model.setting && that.model.setting.path === "mySavedSettings") {
-            height = Math.max(height / 2, scaleFactor * mySavedSettingsMinHeight);
+        height = Math.max(height / 2, scaleFactor * mySavedSettingsMinHeight);
     }
 
     var bounds = gpii.browserWindow.computeWindowBounds(width, height, offsetX, offsetY);

--- a/src/renderer/common/js/utils.js
+++ b/src/renderer/common/js/utils.js
@@ -117,7 +117,7 @@
             }
         } else {
             // there is no value in the config, sending the warning
-            fluid.log(fluid.logLevel.WARN, "Service Buttons (openCloudFolderPresenter): Cannot find a proper url path [siteConfig.qss.urlscloudFolder]");
+            fluid.log(fluid.logLevel.WARN, "Service Buttons (openUrl): Cannot find a proper url path [siteConfig.qss]");
         }
     };
 

--- a/src/renderer/qss/js/qss.js
+++ b/src/renderer/qss/js/qss.js
@@ -49,7 +49,11 @@
             "custom-launch-app": "gpii.qss.customLaunchAppPresenter",
             "custom-open-url":   "gpii.qss.customOpenUrlPresenter",
             // separator grade
-            "separator":         "gpii.qss.separatorButtonPresenter"
+            "separator":         "gpii.qss.separatorButtonPresenter",
+            // url based buttons
+            "url-google-drive":  "gpii.qss.urlGoogleDrivePresenter",
+            "url-one-drive":     "gpii.qss.urlOneDrivePresenter",
+            "url-dropbox":       "gpii.qss.urlDropboxPresenter"
         },
 
         dynamicContainerMarkup: {

--- a/src/renderer/qss/js/qssServiceButtons.js
+++ b/src/renderer/qss/js/qssServiceButtons.js
@@ -288,8 +288,9 @@
     };
 
     /**
-     * Inherits from `gpii.qss.buttonPresenter` and handles interactions with the "Open USB Button"
-     * QSS button.
+     * Inherits from `gpii.qss.buttonPresenter` and handles interactions with the "Open Quick Folder"
+     * QSS button. For all url based buttons we use different siteConfig variable for the data,
+     * but the same function to open the browser.
      */
     fluid.defaults("gpii.qss.openCloudFolderPresenter", {
         gradeNames: ["gpii.qss.buttonPresenter"],
@@ -298,6 +299,60 @@
                 funcName: "gpii.windows.openUrl",
                 args: [
                     "{gpii.qss}.options.siteConfig.urls.cloudFolder",  // siteConfig's cloud folder url
+                    "{gpii.qss}.options.siteConfig.alwaysUseChrome" // Override the OS default browser.
+                ]
+            }
+        }
+    });
+
+    /**
+     * Inherits from `gpii.qss.buttonPresenter` and handles interactions with the "My Google Drive"
+     * QSS button. For all url based buttons we use different siteConfig variable for the data,
+     * but the same function to open the browser.
+     */
+    fluid.defaults("gpii.qss.urlGoogleDrivePresenter", {
+        gradeNames: ["gpii.qss.buttonPresenter"],
+        invokers: {
+            activate: {
+                funcName: "gpii.windows.openUrl",
+                args: [
+                    "{gpii.qss}.options.siteConfig.urls.myGoogleDrive",  // siteConfig's url
+                    "{gpii.qss}.options.siteConfig.alwaysUseChrome" // Override the OS default browser.
+                ]
+            }
+        }
+    });
+
+    /**
+     * Inherits from `gpii.qss.buttonPresenter` and handles interactions with the "My One Drive"
+     * QSS button. For all url based buttons we use different siteConfig variable for the data,
+     * but the same function to open the browser.
+     */
+    fluid.defaults("gpii.qss.urlOneDrivePresenter", {
+        gradeNames: ["gpii.qss.buttonPresenter"],
+        invokers: {
+            activate: {
+                funcName: "gpii.windows.openUrl",
+                args: [
+                    "{gpii.qss}.options.siteConfig.urls.myOneDrive",  // siteConfig's url
+                    "{gpii.qss}.options.siteConfig.alwaysUseChrome" // Override the OS default browser.
+                ]
+            }
+        }
+    });
+
+    /**
+     * Inherits from `gpii.qss.buttonPresenter` and handles interactions with the "My Dropbox"
+     * QSS button. For all url based buttons we use different siteConfig variable for the data,
+     * but the same function to open the browser.
+     */
+    fluid.defaults("gpii.qss.urlDropboxPresenter", {
+        gradeNames: ["gpii.qss.buttonPresenter"],
+        invokers: {
+            activate: {
+                funcName: "gpii.windows.openUrl",
+                args: [
+                    "{gpii.qss}.options.siteConfig.urls.myDropbox",  // siteConfig's url
                     "{gpii.qss}.options.siteConfig.alwaysUseChrome" // Override the OS default browser.
                 ]
             }

--- a/testData/qss/settings.json
+++ b/testData/qss/settings.json
@@ -182,6 +182,33 @@
         "value": false,
         "learnMoreLink": "https://morphic.world/basics/learn-more-about-quickstrip#readaloud"
     }, {
+        "id": "url-google-drive",
+        "path": "url-google-drive",
+        "schema": {
+            "type": "url-google-drive"
+        },
+        "buttonTypes": ["largeButton", "settingButton"],
+        "tabindex": 160,
+        "messageKey": "url-google-drive"
+    }, {
+        "id": "url-one-drive",
+        "path": "url-one-drive",
+        "schema": {
+            "type": "url-one-drive"
+        },
+        "buttonTypes": ["largeButton", "settingButton"],
+        "tabindex": 170,
+        "messageKey": "url-one-drive"
+    }, {
+        "id": "url-dropbox",
+        "path": "url-dropbox",
+        "schema": {
+            "type": "url-dropbox"
+        },
+        "buttonTypes": ["largeButton", "settingButton"],
+        "tabindex": 180,
+        "messageKey": "url-dropbox"
+    }, {
         "id": "cloud-folder-open",
         "path": "cloud-folder-open",
         "schema": {

--- a/tests/fixtures/qssSettings.json
+++ b/tests/fixtures/qssSettings.json
@@ -212,11 +212,38 @@
             "helpImage": "readAloud.png"
         },
         "buttonTypes": ["largeButton", "settingButton"],
-        "tabindex": 80,
+        "tabindex": 90,
         "messageKey": "common-volume",
         "value": 0.5,
         "learnMoreLink": "https://morphic.world/help/qsshelp#volume"
 
+    }, {
+        "id": "url-google-drive",
+        "path": "url-google-drive",
+        "schema": {
+            "type": "url-google-drive"
+        },
+        "buttonTypes": ["largeButton", "settingButton"],
+        "tabindex": 100,
+        "messageKey": "url-google-drive"
+    }, {
+        "id": "url-one-drive",
+        "path": "url-one-drive",
+        "schema": {
+            "type": "url-one-drive"
+        },
+        "buttonTypes": ["largeButton", "settingButton"],
+        "tabindex": 110,
+        "messageKey": "url-one-drive"
+    }, {
+        "id": "url-dropbox",
+        "path": "url-dropbox",
+        "schema": {
+            "type": "url-dropbox"
+        },
+        "buttonTypes": ["largeButton", "settingButton"],
+        "tabindex": 120,
+        "messageKey": "url-dropbox"
     }, {
         "id": "cloud-folder-open",
         "path": "cloud-folder-open",
@@ -224,7 +251,7 @@
             "type": "cloud-folder-open"
         },
         "buttonTypes": ["largeButton", "settingButton"],
-        "tabindex": 180,
+        "tabindex": 130,
         "messageKey": "cloud-folder-open"
     }, {
         "id": "usb-open",
@@ -244,7 +271,7 @@
         "buttonTypes": ["largeButton", "settingButton"],
         "tabindex": 195,
         "messageKey": "launch-documorph"
-    },  {
+    }, {
         "id": "service-more",
         "path": "more",
         "schema": {

--- a/tests/qss/QssTestDefs.js
+++ b/tests/qss/QssTestDefs.js
@@ -28,6 +28,9 @@ require("./qssWidget-screenCaptureTests.js");
 require("./qssWidget-officeSimplifyTests.js");
 require("./qssWidget-stepperTests.js");
 require("./qssWidget-menuTests.js");
+require("./qssWidget-urlGoogleDriveTests.js");
+require("./qssWidget-urlOneDriveTests.js");
+require("./qssWidget-urlDropboxTests.js");
 require("./qssService-undoTests.js");
 require("./qssService-saveTests.js");
 require("./qssService-morePanelTests.js");
@@ -228,7 +231,7 @@ var qssInstalledLanguages = [
 
 gpii.tests.qss.testDefs = {
     name: "QSS Widget integration tests",
-    expect: 74,
+    expect: 77,
     config: {
         configName: "gpii.tests.dev.config",
         configPath: "tests/configs"
@@ -284,6 +287,9 @@ gpii.tests.qss.testDefs = {
         gpii.tests.qss.quickFolderTests,
         gpii.tests.qss.volumeTests,
         gpii.tests.qss.documorphTests,
+        gpii.tests.qss.urlGoogleDrive,
+        gpii.tests.qss.urlOneDrive,
+        gpii.tests.qss.urlDropboxDrive,
         gpii.tests.qss.textZoomTests,
         gpii.tests.qss.readAloudTests,
         gpii.tests.qss.screenCaptureTests,

--- a/tests/qss/qssCommons-navigationTests.js
+++ b/tests/qss/qssCommons-navigationTests.js
@@ -18,7 +18,7 @@
 
 var fluid = require("infusion");
 var gpii  = fluid.registerNamespace("gpii");
-var qssSettingsCount = 16;
+var qssSettingsCount = 19;
 
 var clickCloseBtn = "jQuery(\".fl-qss-btnId-service-close\").click()";
 

--- a/tests/qss/qssWidget-urlDropboxTests.js
+++ b/tests/qss/qssWidget-urlDropboxTests.js
@@ -21,7 +21,7 @@ var gpii  = fluid.registerNamespace("gpii");
 
 var clickCloseBtn = "jQuery(\".fl-qss-btnId-service-close\").click()";
 
-function getDocuMorphWidgetBtnText() {
+function getDropboxDriveWidgetBtnText() {
     return jQuery(".fl-qss-btnId-url-dropbox > span").text();
 }
 
@@ -34,7 +34,7 @@ gpii.tests.qss.urlDropboxDrive = [
         task: "gpii.test.invokeFunctionInWebContents",
         args: [
             "{that}.app.qssWrapper.qss.dialog",
-            getDocuMorphWidgetBtnText
+            getDropboxDriveWidgetBtnText
         ],
         resolve: "jqUnit.assertEquals",
         resolveArgs: [

--- a/tests/qss/qssWidget-urlDropboxTests.js
+++ b/tests/qss/qssWidget-urlDropboxTests.js
@@ -1,0 +1,53 @@
+/*
+ * GPII Sequential Dialogs Integration Test Definitions
+ *
+ * Copyright 2017 OCAD University
+ *
+ * Licensed under the New BSD license. You may not use this file except in
+ * compliance with this License.
+ *
+ * The research leading to these results has received funding from the European Union's
+ * Seventh Framework Programme (FP7/2007-2013)
+ * under grant agreement no. 289016.
+ *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/universal/blob/master/LICENSE.txt
+ */
+
+"use strict";
+
+var fluid = require("infusion");
+var gpii  = fluid.registerNamespace("gpii");
+
+var clickCloseBtn = "jQuery(\".fl-qss-btnId-service-close\").click()";
+
+function getDocuMorphWidgetBtnText() {
+    return jQuery(".fl-qss-btnId-url-dropbox > span").text();
+}
+
+fluid.registerNamespace("gpii.tests.qss.urlDropboxDrive");
+
+gpii.tests.qss.urlDropboxDrive = [
+    { // Open the QSS...
+        func: "{that}.app.tray.events.onTrayIconClicked.fire"
+    }, { // Text of the button should be
+        task: "gpii.test.invokeFunctionInWebContents",
+        args: [
+            "{that}.app.qssWrapper.qss.dialog",
+            getDocuMorphWidgetBtnText
+        ],
+        resolve: "jqUnit.assertEquals",
+        resolveArgs: [
+            "Text of the button should be",
+            "My Dropbox",
+            "{arguments}.0"
+        ]
+    }, { // Close the QSS
+        task: "gpii.test.executeJavaScriptInWebContents",
+        args: [
+            "{that}.app.qssWrapper.qss.dialog",
+            clickCloseBtn
+        ],
+        resolve: "fluid.identity"
+    }
+];

--- a/tests/qss/qssWidget-urlGoogleDriveTests.js
+++ b/tests/qss/qssWidget-urlGoogleDriveTests.js
@@ -1,0 +1,53 @@
+/*
+ * GPII Sequential Dialogs Integration Test Definitions
+ *
+ * Copyright 2017 OCAD University
+ *
+ * Licensed under the New BSD license. You may not use this file except in
+ * compliance with this License.
+ *
+ * The research leading to these results has received funding from the European Union's
+ * Seventh Framework Programme (FP7/2007-2013)
+ * under grant agreement no. 289016.
+ *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/universal/blob/master/LICENSE.txt
+ */
+
+"use strict";
+
+var fluid = require("infusion");
+var gpii  = fluid.registerNamespace("gpii");
+
+var clickCloseBtn = "jQuery(\".fl-qss-btnId-service-close\").click()";
+
+function getDocuMorphWidgetBtnText() {
+    return jQuery(".fl-qss-btnId-url-google-drive > span").text();
+}
+
+fluid.registerNamespace("gpii.tests.qss.urlGoogleDrive");
+
+gpii.tests.qss.urlGoogleDrive = [
+    { // Open the QSS...
+        func: "{that}.app.tray.events.onTrayIconClicked.fire"
+    }, { // Text of the button should be
+        task: "gpii.test.invokeFunctionInWebContents",
+        args: [
+            "{that}.app.qssWrapper.qss.dialog",
+            getDocuMorphWidgetBtnText
+        ],
+        resolve: "jqUnit.assertEquals",
+        resolveArgs: [
+            "Text of the button should be",
+            "My Google Drive",
+            "{arguments}.0"
+        ]
+    }, { // Close the QSS
+        task: "gpii.test.executeJavaScriptInWebContents",
+        args: [
+            "{that}.app.qssWrapper.qss.dialog",
+            clickCloseBtn
+        ],
+        resolve: "fluid.identity"
+    }
+];

--- a/tests/qss/qssWidget-urlGoogleDriveTests.js
+++ b/tests/qss/qssWidget-urlGoogleDriveTests.js
@@ -21,7 +21,7 @@ var gpii  = fluid.registerNamespace("gpii");
 
 var clickCloseBtn = "jQuery(\".fl-qss-btnId-service-close\").click()";
 
-function getDocuMorphWidgetBtnText() {
+function getGoogleDriveWidgetBtnText() {
     return jQuery(".fl-qss-btnId-url-google-drive > span").text();
 }
 
@@ -34,7 +34,7 @@ gpii.tests.qss.urlGoogleDrive = [
         task: "gpii.test.invokeFunctionInWebContents",
         args: [
             "{that}.app.qssWrapper.qss.dialog",
-            getDocuMorphWidgetBtnText
+            getGoogleDriveWidgetBtnText
         ],
         resolve: "jqUnit.assertEquals",
         resolveArgs: [

--- a/tests/qss/qssWidget-urlOneDriveTests.js
+++ b/tests/qss/qssWidget-urlOneDriveTests.js
@@ -21,7 +21,7 @@ var gpii  = fluid.registerNamespace("gpii");
 
 var clickCloseBtn = "jQuery(\".fl-qss-btnId-service-close\").click()";
 
-function getDocuMorphWidgetBtnText() {
+function getOneDriveWidgetBtnText() {
     return jQuery(".fl-qss-btnId-url-one-drive > span").text();
 }
 
@@ -34,7 +34,7 @@ gpii.tests.qss.urlOneDrive = [
         task: "gpii.test.invokeFunctionInWebContents",
         args: [
             "{that}.app.qssWrapper.qss.dialog",
-            getDocuMorphWidgetBtnText
+            getOneDriveWidgetBtnText
         ],
         resolve: "jqUnit.assertEquals",
         resolveArgs: [

--- a/tests/qss/qssWidget-urlOneDriveTests.js
+++ b/tests/qss/qssWidget-urlOneDriveTests.js
@@ -1,0 +1,53 @@
+/*
+ * GPII Sequential Dialogs Integration Test Definitions
+ *
+ * Copyright 2017 OCAD University
+ *
+ * Licensed under the New BSD license. You may not use this file except in
+ * compliance with this License.
+ *
+ * The research leading to these results has received funding from the European Union's
+ * Seventh Framework Programme (FP7/2007-2013)
+ * under grant agreement no. 289016.
+ *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/universal/blob/master/LICENSE.txt
+ */
+
+"use strict";
+
+var fluid = require("infusion");
+var gpii  = fluid.registerNamespace("gpii");
+
+var clickCloseBtn = "jQuery(\".fl-qss-btnId-service-close\").click()";
+
+function getDocuMorphWidgetBtnText() {
+    return jQuery(".fl-qss-btnId-url-one-drive > span").text();
+}
+
+fluid.registerNamespace("gpii.tests.qss.urlOneDrive");
+
+gpii.tests.qss.urlOneDrive = [
+    { // Open the QSS...
+        func: "{that}.app.tray.events.onTrayIconClicked.fire"
+    }, { // Text of the button should be
+        task: "gpii.test.invokeFunctionInWebContents",
+        args: [
+            "{that}.app.qssWrapper.qss.dialog",
+            getDocuMorphWidgetBtnText
+        ],
+        resolve: "jqUnit.assertEquals",
+        resolveArgs: [
+            "Text of the button should be",
+            "My One Drive",
+            "{arguments}.0"
+        ]
+    }, { // Close the QSS
+        task: "gpii.test.executeJavaScriptInWebContents",
+        args: [
+            "{that}.app.qssWrapper.qss.dialog",
+            clickCloseBtn
+        ],
+        resolve: "fluid.identity"
+    }
+];


### PR DESCRIPTION
GPII-4189, GPII-4190, GPII-4191: All three url based buttons (My Google Drive, My One Drive, and My Dropbox) are added

* Added siteConfig variables for all the buttons under qss.urls
* Added ids to be used in the buttonList: "url-google-drive", "url-one-drive", "url-dropbox"
* Added messageBundle variables for the titles and tooltips
* Fixed some linting issues from the previous merges