### PR TITLE
GPII-4178: Updated windows reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "electron": "3.0.2",
         "electron-edge-js": "8.3.8",
         "electron-localshortcut": "3.1.0",
-        "gpii-windows": "javihernandez/windows#f2efbb63ea4c8fe42a9f27c808569f632121e58a",
+        "gpii-windows": "0.3.0-dev.20191017T162536Z.acb3d40",
         "infusion": "3.0.0-dev.20190328T144119Z.ec44dbfab",
         "nan": "2.10.0",
         "node-jqunit": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "electron": "3.0.2",
         "electron-edge-js": "8.3.8",
         "electron-localshortcut": "3.1.0",
-        "gpii-windows": "0.3.0-dev.20190930T092641Z.74b8070",
+        "gpii-windows": "javihernandez/windows#f2efbb63ea4c8fe42a9f27c808569f632121e58a",
         "infusion": "3.0.0-dev.20190328T144119Z.ec44dbfab",
         "nan": "2.10.0",
         "node-jqunit": "1.1.8",

--- a/provisioning/Build.ps1
+++ b/provisioning/Build.ps1
@@ -30,7 +30,7 @@ Import-Module $bootstrapModule -Verbose -Force
 # # Run all the windows provisioning scripts
 # ############
 # TODO: Create function for downloading scripts and executing them.
-$windowsBootstrapURL = "https://raw.githubusercontent.com/javihernandez/windows/GPII-3744/provisioning"
+$windowsBootstrapURL = "https://raw.githubusercontent.com/GPII/windows/master/provisioning"
 try {
     $choco = Join-Path $originalBuildScriptPath "Chocolatey.ps1"
     Write-OutPut "Running windows script: $choco"


### PR DESCRIPTION
This windows update brings the ability to build and run the tests in
Windows 10 1903.