### PR TITLE
GPII-4135: Add new custom button type - key sequencer

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "electron": "3.0.2",
         "electron-edge-js": "8.3.8",
         "electron-localshortcut": "3.1.0",
-        "gpii-windows": "0.3.0-dev.20191017T162536Z.acb3d40",
+        "gpii-windows": "stegru/windows#GPII-4135",
         "infusion": "3.0.0-dev.20190328T144119Z.ec44dbfab",
         "nan": "2.10.0",
         "node-jqunit": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "electron": "3.0.2",
         "electron-edge-js": "8.3.8",
         "electron-localshortcut": "3.1.0",
-        "gpii-windows": "stegru/windows#GPII-4135",
+        "gpii-windows": "0.3.0-dev.20191106T150515Z.cadcb7c",
         "infusion": "3.0.0-dev.20190328T144119Z.ec44dbfab",
         "nan": "2.10.0",
         "node-jqunit": "1.1.8",

--- a/siteconfig.json5
+++ b/siteconfig.json5
@@ -55,24 +55,34 @@
 
         // list of the desired list of buttons shown in QSS
         // it uses the `id` attribute found in settings.json items
-        // 
+
         // Custom buttons: Instead of a string with buttonId you add an object with the custom button data like this:
+        // APP type buttons require absolute path to executable in the buttonData
+        // WEB type buttons require a real valid url in the buttonData
+        // KEY type buttons require a key combation with this exact syntax:
+        // https://github.com/stegru/windows/blob/GPII-4135/gpii/node_modules/gpii-userInput/README.md
         // {
         //      "buttonId": "MakeYourOwn",
         //      "buttonName": "Launch Notepad", // Free text that will be use as button's label
-        //      "buttonType": "APP", // APP, or WEB
-        //      "buttonData": "C:\\Windows\\system32\\notepad.exe", // system path, or url
+        //      "buttonType": "APP", // APP, WEB, or KEY
+        //      "buttonData": "C:\\Windows\\system32\\notepad.exe", // system path, or url, or key combination
         //      "fullScreen": true, // true, or false
         //      "popupText": "<p>Launch the Notepad application.</p>", // tooltip text
         //      "description": "The full description of the button..." // optional description
         // }
-        // 
+
         // Separator buttons: Use can use any combination of the separators, even one after another:
-        // "separator" // Use separator for invisible separator
-        // "separator-visible" // Use separator-visible for a gray separator (same size as the invisible one)
-         
+        // - "separator" // Use separator for invisible separator
+        // - "separator-visible" // Use separator-visible for a gray separator (same size as the invisible one)
+
         buttonList: [
             {
+                "buttonId": "MakeYourOwn",
+                "buttonName": "Task Manager",
+                "buttonType": "KEY",
+                "buttonData": "^+{Escape}",
+                "popupText": "<p>Executes Ctrl+Shift+Esc combination, which opens Windows Task Manager.</p>"
+            }, {
                 "buttonId": "MakeYourOwn",
                 "buttonName": "Launch Notepad",
                 "buttonType": "APP",

--- a/src/main/common/utils.js
+++ b/src/main/common/utils.js
@@ -258,20 +258,21 @@ gpii.app.expect = function (dataObject, expectedKeys, warningSend, warningTitle)
 gpii.app.generateCustomButton = function (buttonData) {
     var serviceButtonTypeApp = "custom-launch-app",
         serviceButtonTypeWeb = "custom-open-url",
+        serviceButtonTypeKey = "custom-keys",
         titleAppNotFound = "Program not found",
         titleUrlInvalid = "Invalid URL",
+        titleNoKeyData = "No Key Data",
         disabledStyle = "disabledButton",
         data = false;
 
     // we need to have the data, with all required fields:
     // buttonId, buttonName, buttonType, buttonData
     if (gpii.app.expect(buttonData, ["buttonId", "buttonName", "buttonType", "buttonData"], true, "generateCustomButton")) {
-        var buttonType = buttonData.buttonType === "APP" ? serviceButtonTypeApp : serviceButtonTypeWeb;
         data = {
             "id": buttonData.buttonId,
-            "path": buttonType,
+            "path": serviceButtonTypeWeb, // default
             "schema": {
-                "type": buttonType,
+                "type": serviceButtonTypeWeb,
                 "title": buttonData.buttonName,
                 "fullScreen": false
             },
@@ -286,6 +287,9 @@ gpii.app.generateCustomButton = function (buttonData) {
             data.schema.fullScreen = true;
         }
         if (buttonData.buttonType === "APP") {
+            // APP type button
+            data.path = serviceButtonTypeApp;
+            data.schema.type = serviceButtonTypeApp;
             // checks if the file exists and its executable
             if (gpii.app.checkExecutable(buttonData.buttonData)) {
                 // adding the application's path
@@ -296,7 +300,21 @@ gpii.app.generateCustomButton = function (buttonData) {
                 // disables the button
                 data.buttonTypes.push(disabledStyle);
             }
+        } else if (buttonData.buttonType === "KEY") {
+            // KEY type button
+            data.path = serviceButtonTypeKey;
+            data.schema.type = serviceButtonTypeKey;
+            if (fluid.isValue(buttonData.buttonData)) {
+                // adding the key sequence data to the schema
+                data.schema.keyData = buttonData.buttonData;
+            } else {
+                // changes the button's title
+                data.schema.title = titleNoKeyData;
+                // disables the button
+                data.buttonTypes.push(disabledStyle);
+            }
         } else {
+            // WEB type button
             // adding the http if its missing
             if (buttonData.buttonData.indexOf("https://") === -1 && buttonData.buttonData.indexOf("http://") === -1) {
                 buttonData.buttonData = "http://" + buttonData.buttonData;
@@ -518,4 +536,20 @@ gpii.app.startProcess = function (process, fullScreen) {
     }
     // executing the process
     gpii.windows.startProcess(process, arg, options);
+};
+
+/**
+ * Executes the key sequence using the sendKeys command, documentation
+ * https://github.com/stegru/windows/blob/GPII-4135/gpii/node_modules/gpii-userInput/README.md
+ * @param  {String} keyData - string with key combinations
+ * @return {Boolean} true if there is a keyData to be execute, false otherwise
+ */
+gpii.app.executeKeySequence = function (keyData) {
+    if (fluid.isValue(keyData)) {
+        gpii.windows.sendKeys.send(keyData);
+        return true;
+    } else {
+        fluid.log(fluid.logLevel.WARN, "executeKeySequence: Empty or invalid keyData");
+    }
+    return false;
 };

--- a/src/main/dialogs/quickSetStrip/qssDialog.js
+++ b/src/main/dialogs/quickSetStrip/qssDialog.js
@@ -149,7 +149,8 @@ fluid.defaults("gpii.app.qss", {
                     onQssPspToggled: null,
 
                     // Custom buttons events
-                    onQssStartProcess: null
+                    onQssStartProcess: null,
+                    onQssExecuteKeySequence: null
                 },
 
                 listeners: {
@@ -166,6 +167,10 @@ fluid.defaults("gpii.app.qss", {
                             "{arguments}.0",
                             "{arguments}.1"
                         ]
+                    },
+                    onQssExecuteKeySequence: {
+                        funcName: "gpii.app.executeKeySequence",
+                        args: ["{arguments}.0"]
                     }
                 }
             }

--- a/src/renderer/qss/js/qss.js
+++ b/src/renderer/qss/js/qss.js
@@ -49,6 +49,7 @@
             // custom button grades
             "custom-launch-app": "gpii.qss.customLaunchAppPresenter",
             "custom-open-url":   "gpii.qss.customOpenUrlPresenter",
+            "custom-keys":       "gpii.qss.customKeysPresenter",
             // separator grade
             "separator":         "gpii.qss.separatorButtonPresenter",
             // url based buttons
@@ -244,7 +245,8 @@
                         onQssSaveRequired: "{quickSetStripList}.events.onSaveRequired",
 
                         // Custom buttons events
-                        onQssStartProcess: null
+                        onQssStartProcess: null,
+                        onQssExecuteKeySequence: null
                     }
                 }
             }

--- a/src/renderer/qss/js/qssServiceButtons.js
+++ b/src/renderer/qss/js/qssServiceButtons.js
@@ -233,6 +233,34 @@
     });
 
     /**
+     * Inherits from `gpii.qss.buttonPresenter` and handles interactions with the
+     * custom buttons that need to execute key sequence or key combination, it requires
+     * a key data and a handle to the onQssExecuteKeySequence event, documentation:
+     * https://github.com/stegru/windows/blob/GPII-4135/gpii/node_modules/gpii-userInput/README.md
+     */
+    fluid.defaults("gpii.qss.customKeysPresenter", {
+        gradeNames: ["gpii.qss.buttonPresenter"],
+        invokers: {
+            activate: {
+                funcName: "gpii.qss.executeKeySequence",
+                args: [
+                    "{that}.model.item.schema.keyData", // using the key data from the custom button's schema
+                    "{channelNotifier}.events.onQssExecuteKeySequence"
+                ]
+            }
+        }
+    });
+
+    /**
+     * Custom function that handles executing the key sequence
+     * @param  {String} keyData - string with key combinations
+     * @param  {Event} executeKeyEvent - handle to the onQssExecuteKeySequence event
+     */
+    gpii.qss.executeKeySequence = function (keyData, executeKeyEvent) {
+        executeKeyEvent.fire(keyData);
+    };
+
+    /**
      * Inherits from `gpii.qss.buttonPresenter` and handles interactions with the "Undo"
      * QSS button.
      */


### PR DESCRIPTION
Added new key sequencer type custom button

* Added new "buttonType": "KEY" in the buttonList's custom type buttons
* Handling the new custom type in gpii.app.generateCustomButton as well, generating "custom-keys" type setting
* Created new gpii.qss.customKeysPresenter for the custom key setting
* Added onQssExecuteKeySequence event which uses Steve's gpii.windows.sendKeys.send() to send the keys to Windows