### PR TITLE
GPII-4253: Made gpii-windows package an optional (OS-whitelisted) dependency

### DIFF
--- a/main.js
+++ b/main.js
@@ -58,8 +58,9 @@ app.on("second-instance", function (event, commandLine) {
     }
 });
 
-// this module is loaded relatively slow
+// this module is loaded relatively slowly
 // it also loads gpii-universal
+// NOTE: if the OS-specific support package was not loaded successfully, the require(".../index.js") function will throw an exception
 require("gpii-windows/index.js");
 
 require("./index.js");

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
         "electron": "3.0.2",
         "electron-edge-js": "8.3.8",
         "electron-localshortcut": "3.1.0",
-        "gpii-windows": "0.3.0-dev.20191106T150515Z.cadcb7c",
         "infusion": "3.0.0-dev.20190328T144119Z.ec44dbfab",
         "nan": "2.10.0",
         "node-jqunit": "1.1.8",
@@ -34,6 +33,9 @@
         "nyc": "13.0.1",
         "rimraf": "2.6.2",
         "shelljs": "0.8.2"
+    },
+    "optionalDependencies": {
+        "gpii-windows": "0.3.0-dev.20191204T181313Z.b920f98.GPII-4253"
     },
     "scripts": {
         "start": "set GPII_TEST_COUCH_USE_EXTERNAL=TRUE && electron .",


### PR DESCRIPTION
Notes for posterity:

npm does not currently have robust support for OS-specific package dependencies in an app's package.json file.

To make the Morphic QuickStrip (gpii-app) cross-platform, the OS-specific packages have been whitelisted for their specific OS in their package.json files ("win32" for Windows, "darwin" for macOS, etc.).

These OS-specific packages have been moved from the "dependencies" section in our app's package.json file to the "optionalDependencies" section.  When executing an npm install, npm will therefore not pull in the OS-specific optionalDependencies which do not apply to the host OS.

Please note that marking our OS-specific dependencies as optional dependencies has a side-effect: if their npm installation fails, it may fail silently.  If this causes significant confusion or other issues for project development, we may want to consider a "node-gyp" approach to pulling in OS-specific dependencies.  We may also want to consider using a postinstall script which dynamically npm installs the appropriate dependency; however such a postinstall script is generally not recommended since it would self-modify the package.json file (therefore creating an unusual exception for our git check-in workflow).