### PR TITLE
GPII-3925: Knowing the tray button position

### DIFF
--- a/src/main/tray.js
+++ b/src/main/tray.js
@@ -79,7 +79,8 @@ fluid.defaults("gpii.app.tray", {
         isMouseOver: {
             funcName: "gpii.app.isMouseOverTray",
             args: ["{that}"]
-        }
+        },
+        getIconBounds: "fluid.notImplemented"
     }
 });
 
@@ -225,6 +226,10 @@ fluid.defaults("gpii.app.trayButton", {
         updateButton: {
             func: "{that}.sendDataMessage", // command, data
             args: [ "{that}.trayButtonWindow", "{arguments}.0", "{arguments}.1" ]
+        },
+        getIconBounds: {
+            funcName: "fluid.identity",
+            args: [ "{that}.rect" ]
         }
     },
     listeners: {
@@ -260,6 +265,8 @@ fluid.defaults("gpii.app.trayButton", {
         // Path to the tray button window.
         trayButtonWindow: ["Shell_TrayWnd", "GPII-TrayButton"],
         trayButtonMessage: "GPII-TrayButton-Message",
+        trayButtonPositionMessage: "GPII-TrayButtonPos-Message",
+        rect: {},
         menu: null,
         // true if the mouse pointer is currently over the button
         mouseOver: false
@@ -354,8 +361,9 @@ gpii.app.trayButton.setMenu = function (that, menu) {
  * @param {Number} hwnd The message window.
  * @param {Number|String} msg The message.
  * @param {Number} wParam Message data.
+ * @param {Number} lParam Extra message data.
  */
-gpii.app.trayButton.windowMessage = function (that, hwnd, msg, wParam) {
+gpii.app.trayButton.windowMessage = function (that, hwnd, msg, wParam, lParam) {
     if (msg === that.trayButtonMessage) {
         switch (wParam) {
         case gpii.app.trayButton.notifications.click:
@@ -386,5 +394,14 @@ gpii.app.trayButton.windowMessage = function (that, hwnd, msg, wParam) {
         default:
             break;
         }
+    } else if (msg === that.trayButtonPositionMessage) {
+        var lParamValue = lParam.address();
+        // The bounding rectangle is 4 shorts crammed in both the message parameters.
+        that.rect = {
+            x: wParam & 0xffff,
+            y: (wParam >> 16) & 0xffff,
+            width: lParamValue & 0xffff,
+            height: (lParamValue >> 16) & 0xffff
+        };
     }
 };

--- a/tests/TrayButtonTests.js
+++ b/tests/TrayButtonTests.js
@@ -96,7 +96,7 @@ jqUnit.asyncTest("Testing tray button", function () {
 
     var tests = gpii.tests.app.trayButton.buttonTests;
     var checkButtonExpects = 3;
-    jqUnit.expect(checkButtonExpects * (tests.length + 2) + 6);
+    jqUnit.expect(checkButtonExpects * (tests.length + 2) + 7);
 
     // Make sure there isn't a button already (from another instance).
     var buttonWindows = gpii.windows.findWindows(["Shell_TrayWnd", "GPII-TrayButton"]);
@@ -156,6 +156,17 @@ jqUnit.asyncTest("Testing tray button", function () {
                 trayButton.applier.change(test.name, test.value);
                 gpii.tests.app.trayButton.checkButton(buttonWindow, taskbarWindow);
             });
+
+            // Check getIconBounds() is correct.
+            var buttonRect = gpii.windows.getWindowRect(buttonWindow);
+            var rect = {
+                x: buttonRect.left,
+                y: buttonRect.top,
+                width: buttonRect.width,
+                height: buttonRect.height
+            };
+
+            jqUnit.assertDeepEq("getIconBounds must return the button window rect", rect, trayButton.getIconBounds());
 
             // Kill the button process, it should restart.
             gpii.windows.killProcessByName("tray-button.exe");

--- a/trayButton/tray-button.c
+++ b/trayButton/tray-button.c
@@ -35,6 +35,7 @@
 #define BUTTON_CLASS L"GPII-TrayButton"
 #define GPII_CLASS L"gpii-message-window"
 #define BUTTON_MESSAGE L"GPII-TrayButton-Message"
+#define BUTTON_POSITION_MESSAGE L"GPII-TrayButtonPos-Message"
 
 // Commands sent from GPII
 #define GPII_COMMAND_ICON    1
@@ -66,7 +67,7 @@
 /** Current state of the button */
 int buttonState = STATE_NORMAL;
 /** last known window sizes */
-RECT taskRect = { 0 }, notifyRect = { 0 }, trayClient = { 0 };
+RECT taskRect = { 0 }, notifyRect = { 0 }, trayClient = { 0 }, windowRect = { 0 };
 
 HWND buttonWindow = null;
 HWND tooltipWindow = null;
@@ -84,6 +85,7 @@ WCHAR *iconFileHC = null;
 /** WM_SHELLHOOKMESSAGE */
 UINT shellMessage = 0;
 UINT gpiiMessage = 0;
+UINT gpiiPositionMessage = 0;
 HANDLE gpiiWindow = null;
 
 /** true if the button destruction is intentional */
@@ -300,6 +302,18 @@ BOOL positionTrayWindows(BOOL force)
 		SetTimer(buttonWindow, TIMER_CHECK, 1000, null);
 	} else {
 		KillTimer(buttonWindow, TIMER_RESIZE);
+	}
+
+	if (changed) {
+		// Inform gpii about the new position.
+		RECT currentRect;
+		GetWindowRect(buttonWindow, &currentRect);
+		if (!EqualRect(&windowRect, &currentRect)) {
+			windowRect = currentRect;
+			sendToGpii(gpiiPositionMessage,
+				MAKELONG(windowRect.left, windowRect.top),
+				MAKELONG(windowRect.right - windowRect.left, windowRect.bottom - windowRect.top));
+		}
 	}
 	return changed;
 }
@@ -785,6 +799,7 @@ int CALLBACK WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPSTR cmd, int show)
 
 	// Used to communicate with GPII
 	gpiiMessage = RegisterWindowMessage(BUTTON_MESSAGE);
+	gpiiPositionMessage = RegisterWindowMessage(BUTTON_POSITION_MESSAGE);
 
 	// See if there's already an instance
 	HANDLE existing = FindWindowEx(getTaskbarWindow(), null, BUTTON_CLASS, null);


### PR DESCRIPTION
For @Karadaliev, this PR is just to run it through CI, but you can just pick/merge this.

The function can be called like: `{tray}.getIconBounds()`, returns `{x:, y:, width:, height:}`