### PR TITLE
GPII-3958: Adjust gpii-app to work with the new PSPChannel API.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,5 +31,5 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provision "shell", path: "provisioning/Build.ps1", args: "-originalBuildScriptPath \"C:\\vagrant\\provisioning\\\""
-  config.vm.provision "shell", path: "provisioning/Installer.ps1", args: "-provisioningDir \"C:\\vagrant\\provisioning\\\""
+  #config.vm.provision "shell", path: "provisioning/Installer.ps1", args: "-provisioningDir \"C:\\vagrant\\provisioning\\\""
 end

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "shelljs": "0.8.2"
     },
     "optionalDependencies": {
-        "gpii-windows": "0.3.0-dev.20191204T181313Z.b920f98.GPII-4253"
+        "gpii-windows": "cindyli/windows#GPII-3958"
     },
     "scripts": {
         "start": "set GPII_TEST_COUCH_USE_EXTERNAL=TRUE && electron .",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "shelljs": "0.8.2"
     },
     "optionalDependencies": {
-        "gpii-windows": "cindyli/windows#GPII-3958"
+        "gpii-windows": "0.3.0-dev.20200222T110910Z.95bbada5"
     },
     "scripts": {
         "start": "set GPII_TEST_COUCH_USE_EXTERNAL=TRUE && electron .",

--- a/src/main/gpiiConnector.js
+++ b/src/main/gpiiConnector.js
@@ -278,7 +278,7 @@ gpii.app.extractPreferencesData = function (message, defaultPreferences) {
         contexts = preferences.contexts,
         gpiiKey = value.gpiiKey,
         sets = [],
-        activeSet = value.activeContextName || null,
+        activeSet = value.activePrefsSetName || null,
         settingGroups = [];
 
     if (contexts) {
@@ -831,7 +831,7 @@ gpii.app.dev.gpiiConnector.qss.distributeQssSettings = function (that, message) 
         // the type of update in the future
         that.previousState = {
             gpiiKey: value.gpiiKey,
-            activeSet: value.activeContextName
+            activeSet: value.activePrefsSetName
         };
     }
 };

--- a/src/main/gpiiConnector.js
+++ b/src/main/gpiiConnector.js
@@ -78,7 +78,7 @@ fluid.defaults("gpii.app.gpiiConnector", {
         },
         updateActivePrefSet: {
             funcName: "gpii.app.gpiiConnector.updateActivePrefSet",
-            args: ["{that}", "{arguments}.0"] // newPrefSet
+            args: ["{that}", "{arguments}.0"] // newPrefsSet
         }
     }
 });
@@ -117,11 +117,11 @@ gpii.app.gpiiConnector.updateSetting = function (gpiiConnector, setting) {
 
     fluid.log("gpiiConnector: Alter setting - ", setting);
 
-    gpiiConnector.send({
-        path: ["settingControls", setting.path, "value"],
-        type: "ADD",
-        value: setting.value
-    });
+    var settingChanges = {
+        type: "modelChanged"
+    };
+    fluid.set(settingChanges, ["value", "settingControls", setting.path, "value"], setting.value);
+    gpiiConnector.send(settingChanges);
 };
 
 
@@ -212,14 +212,14 @@ gpii.app.gpiiConnector.handleRawChannelMessage = function (gpiiConnector, messag
 /**
  * Sends an active set change request to GPII.
  * @param {Object} gpiiConnector - The `gpii.app.gpiiConnector` instance
- * @param {String} newPrefSet - The path of the new preference set
+ * @param {String} newPrefsSet - The path of the new preference set
  */
-gpii.app.gpiiConnector.updateActivePrefSet = function (gpiiConnector, newPrefSet) {
-    gpiiConnector.send({
-        path: ["activeContextName"],
-        type: "ADD",
-        value: newPrefSet
-    });
+gpii.app.gpiiConnector.updateActivePrefSet = function (gpiiConnector, newPrefsSet) {
+    var prefsSetChange = {
+        type: "modelChanged"
+    };
+    fluid.set(prefsSetChange, ["value", "activePrefsSetName"], newPrefsSet);
+    gpiiConnector.send(prefsSetChange);
 };
 
 /**

--- a/tests/PreferencesGroupingTests.js
+++ b/tests/PreferencesGroupingTests.js
@@ -70,7 +70,7 @@ var settingGroupsFixture = {
         "type":"ADD",
         "value":{
             "userToken":"snapset_1a",
-            "activeContextName":"gpii-default",
+            "activePrefsSetName":"gpii-default",
             "settingControls":{
                 "http://registry\\.gpii\\.net/common/magnification":{
                     "value":2,

--- a/tests/PreferencesParsingTests.js
+++ b/tests/PreferencesParsingTests.js
@@ -35,7 +35,7 @@ var multiPrefSetsFixture = {
     "type":"ADD",
     "value":{
         "userToken":"context1",
-        "activeContextName":"gpii-default",
+        "activePrefsSetName":"gpii-default",
         "settingGroups": [
             {
                 "solutionName": "Magnifier",


### PR DESCRIPTION
With [the change of PSPChannel API](https://github.com/GPII/universal/pull/826) being merged into the universal repo, gpii-app stops working with the universal master. 

PSPChannel now expects a slightly different incoming message while PSPChannel output messages stay unchanged. The PSPChannel API is [here](https://github.com/GPII/universal/blob/master/documentation/PSPChannel.md).

This pull request adjusts gpii-app to work with the new API. @Karadaliev or @krisYanachkov, I'm not sure if it covers all messages sent to PSPChannel (Local flow manager). Please have a look. Thanks.

Please don't merge this pull request directly since it is pointing to my own gpii/windows branch which pulls in the universal master branch.