### PR TITLE
GPII-4355: Updated build scripts and projects to use VS2017 build tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "shelljs": "0.8.2"
     },
     "optionalDependencies": {
-        "gpii-windows": "0.3.0-dev.20191204T181313Z.b920f98.GPII-4253"
+        "gpii-windows": "github:christopher-rtf/windows#baf9256"
     },
     "scripts": {
         "start": "set GPII_TEST_COUCH_USE_EXTERNAL=TRUE && electron .",

--- a/provisioning/Installer.ps1
+++ b/provisioning/Installer.ps1
@@ -108,9 +108,13 @@ Copy-Item "$packagedAppDir\*" $stagingWindowsDir -Recurse
 md (Join-Path $installerDir "output")
 md (Join-Path $installerDir "temp")
 
-Invoke-Environment "C:\Program Files (x86)\Microsoft Visual C++ Build Tools\vcbuildtools_msbuild.bat"
+# For Microsoft's build tools, we will accept any version >=15.0 and <16.0 (i.e. VS2017)
+$visualStudioVersion = "[15.0,16.0)"
+
+$vsmsbuildcmd = Get-VsMSBuildCmd $visualStudioVersion
+Invoke-Environment vsmsbuildcmd
 $setupDir = Join-Path $installerDir "setup"
-$msbuild = Get-MSBuild "4.0"
+$msbuild = Get-MSBuild $visualStudioVersion
 Invoke-Command $msbuild "setup.msbuild" $setupDir
 
 # Copy the installer into the c:/vagrant folder

--- a/provisioning/Provisioning.psm1
+++ b/provisioning/Provisioning.psm1
@@ -48,19 +48,95 @@ Function Invoke-Command {
 Function Get-MSBuild {
   Param (
     [Parameter(Mandatory=$true)]
-    [string] $version
+    [string] $visualStudioVersion
   )
 
-  # TODO: Check version validity.
-  # Valid versions are [2.0, 3.5, 4.0]
+  # Find the path to vswhere (which installed with Visual Studio 2017 or Build Tools 2017 or later)
+  $vswhere = Get-VSWhere
 
-  $dotNetVersion = $version
-  $regKey = "HKLM:\software\Microsoft\MSBuild\ToolsVersions\$dotNetVersion"
-  $regProperty = "MSBuildToolsPath"
+  if (!$vswhere) {
+    throw "Visual Studio $($visualStudioVersion) or Build Tools $($visualStudioVersion) were not found."
+  }
 
-  $msbuild = Join-Path -path (Get-ItemProperty $regKey).$regProperty -childpath "msbuild.exe"
+  # courtesy of Microsoft: https://github.com/microsoft/vswhere/wiki/Find-MSBuild/62adac8eb22431fa91d94e03503d76d48a74939c
+  $path = &$vswhere -version $visualStudioVersion -products * -requires Microsoft.Component.MSBuild -property installationPath
+  if ($path) {
+    $msbuild = Join-Path $path 'MSBuild\Current\Bin\MSBuild.exe'
+    if (-not (test-path $msbuild)) {
+      $msbuild = join-path $path 'MSBuild\15.0\Bin\MSBuild.exe'
+      if (-not (test-path $msbuild)) {
+        throw "MSBuild from Visual Studio $($visualStudioVersion) or Build Tools $($visualStudioVersion) could not be found"
+      }
+    }
+  }
 
   return $msbuild
+}
+
+Function Get-CSharpCompiler {
+  Param (
+    [Parameter(Mandatory=$true)]
+    [string] $visualStudioVersion
+  )
+
+  # Find the path to vswhere (which installed with Visual Studio 2017 or Build Tools 2017 or later)
+  $vswhere = Get-VSWhere
+
+  if (!$vswhere) {
+    throw "Visual Studio $($visualStudioVersion) or Build Tools $($visualStudioVersion) were not found."
+  }
+
+  # adapted from: https://github.com/microsoft/vswhere/wiki/Find-MSBuild/62adac8eb22431fa91d94e03503d76d48a74939c
+  $path = &$vswhere -version $visualStudioVersion -products * -requires Microsoft.VisualStudio.Component.Roslyn.Compiler -property installationPath
+  if ($path) {
+    $csc = Join-Path $path 'MSBuild\Current\Bin\Roslyn\csc.exe'
+    if (-not (test-path $csc)) {
+      $csc = join-path $path 'MSBuild\15.0\Bin\Roslyn\csc.exe'
+      if (-not (test-path $csc)) {
+        throw "csc from Visual Studio $($visualStudioVersion) or Build Tools $($visualStudioVersion) could not be found"
+      }
+    }
+  }
+
+  return $csc
+}
+
+Function Get-VsMSBuildCmd {
+  Param (
+    [Parameter(Mandatory=$true)]
+    [string] $visualStudioVersion
+  )
+
+  # Find the path to vswhere (which installed with Visual Studio 2017 or Build Tools 2017 or later)
+  $vswhere = Get-VSWhere
+
+  if (!$vswhere) {
+    throw "Visual Studio $($visualStudioVersion) or Build Tools $($visualStudioVersion) were not found."
+  }
+
+  # adapted from: https://github.com/microsoft/vswhere/wiki/Find-MSBuild/62adac8eb22431fa91d94e03503d76d48a74939c
+  # TODO: determine if this batch file is _definitely_ included with Microsoft.Component.MSBuild; we tried Microsoft.VisualStudio.Component.CoreBuildTools and that was _not_ it.
+  $path = &$vswhere -version $visualStudioVersion -products * -requires Microsoft.Component.MSBuild -property installationPath
+  if ($path) {
+    $vsmsbuildcmd = Join-Path $path 'Tools\VsMSBuildCmd.bat'
+  }
+
+  return $vsmsbuildcmd
+}
+
+Function Get-VSWhere {
+  # NOTE: this function is compatible with Visual Studio 2017+
+
+  # Valid Visual Studio versions options are [15.0, "[15.0,16.0)", etc.]
+
+  # Find the path to vswhere (which installed with Visual Studio 2017 or Build Tools 2017 or later)
+  if (${Env:ProgramFiles(x86)}) {
+    $vswhere = Join-Path ${Env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+  } else {
+    $vswhere = Join-Path ${Env:ProgramFiles} "Microsoft Visual Studio\Installer\vswhere.exe"
+  }
+
+  return $vswhere
 }
 
 Function Invoke-Environment {
@@ -108,5 +184,7 @@ Function Add-Path {
 
 Export-ModuleMember -Function Invoke-Command
 Export-ModuleMember -Function Get-MSBuild
+Export-ModuleMember -Function Get-CSharpCompiler
+Export-ModuleMember -Function Get-VsMSBuildCmd
 Export-ModuleMember -Function Invoke-Environment
 Export-ModuleMember -Function Add-Path

--- a/trayButton/tray-button.vcxproj
+++ b/trayButton/tray-button.vcxproj
@@ -28,7 +28,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
This PR, combined with the windows/GPII-4355 PR, should fully enable Morphic for Windows to compile using modern (VS2017) developer tools and Node.js v10.16.3.

Please note that this branch updates package.json to pull in the respective windows GPII-4355 repo; that should of course be modified to point to the proper merged "windows" repo in github.com/GPII.

Critical: developers must upgrade their developer environment to Visual Studio 2017.  The new build scripts use Microsoft's new "vswhere" utility (included with VS2017+) to locate MSBuild, CSC, environment variables, etc.  This is a hard fork in the road...and we will need all the developers on our team (plus the CI environment) to move to VS2017 when this goes "live" in master.

For the future: The $visualStudioVersion PowerShell variable has been designed to support either a specific version (e.g. "15.0" for VS2017) or a range (e.g. "[15.0,16.0)" as an inclusive range for any VS2017'ish releases from v15.0 to v15.9999999999).  This means that as we want to start adding support for VS2019 or other newer releases, we can simplly update the $visualStudioVersion variable to include a wider range of compiler versions.  Our build may indeed be compatible with VS2019 as well, but I have not tested with VS2019 due to the fact that Electron still uses VS2017 in their documentation.