### PR TITLE
GPII-4409: MYOB launchers activate an existing application instance.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "shelljs": "0.8.2"
     },
     "optionalDependencies": {
-        "gpii-windows": "0.3.0-dev.20200316T130633Z.d2a0e074"
+        "gpii-windows": "stegru/windows#GPII-4409"
     },
     "scripts": {
         "start": "set GPII_TEST_COUCH_USE_EXTERNAL=TRUE && electron .",

--- a/src/main/common/utils.js
+++ b/src/main/common/utils.js
@@ -567,13 +567,16 @@ gpii.app.checkUrl = function (url) {
 };
 
 /**
- * Starting a new process with the gpii.windows.startProfcess
+ * Starting a new process with the gpii.windows.startProcess. If there's already an instance of the executable running,
+ * then that is activated instead.
  * @param {String} process - file path to the process executable
  * @param {Boolean} fullScreen - true/false if the process to be maximized by default
  */
 gpii.app.startProcess = function (process, fullScreen) {
-    var arg = "", // by default all of the arguments are empty, reserved for future
-        options = {}; // no options by default
+    var arg = ""; // by default all of the arguments are empty, reserved for future
+    var options = {
+        activateRunning: true
+    };
 
     if (fullScreen) {
         // we are adding the maximized option when the full screen is requested


### PR DESCRIPTION
This the MYOB application launch buttons check if there's already a running instance of the application, then activate the window. If there isn't an instance, it will be started like normal.

To test:
- Click the `Launch Notepad` button a few times.