### PR TITLE
GPII-4425: Updated Vagrantfile to update Chrome and Firefox as gpii/windows does

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,6 +30,10 @@ Vagrant.configure(2) do |config|
     vm.customize ["setextradata", "global", "GUI/SuppressMessages", "all"]
   end
 
+  config.vm.provision "shell", inline: <<-SHELL
+    choco upgrade firefox googlechrome -y
+  SHELL
+
   config.vm.provision "shell", path: "provisioning/Build.ps1", args: "-originalBuildScriptPath \"C:\\vagrant\\provisioning\\\""
   #config.vm.provision "shell", path: "provisioning/Installer.ps1", args: "-provisioningDir \"C:\\vagrant\\provisioning\\\""
 end


### PR DESCRIPTION
This will also install Chrome in the last version of the vagrant box (2020.02.11), where Chrome is missing, see https://issues.gpii.net/browse/GPII-4425.

If you're missing Chrome and don't want to provision the machine again, run (as admin) `choco install googlechrome`