### PR TITLE
GPII-4439: Buttons GREY if they will not work with this version of Morphic 

### DIFF
--- a/messageBundles/gpii-app-messageBundle_bg.json
+++ b/messageBundles/gpii-app-messageBundle_bg.json
@@ -35,6 +35,8 @@
         "keyedIn": "Вашите настройки са запазени в Morphic Cloud."
     },
 
+    "gpii_qss_unknownButtonPresenter_notification": "Бутонът не се поддържа от тази версия на Morphic. За да проработи Трябва да обновите Morphic.",
+
     "gpii_qssWidget_volumeStepper_incrementButton": "По-силно",
     "gpii_qssWidget_volumeStepper_decrementButton": "По-тихо",
     "gpii_qssWidget_volumeStepper_upperBoundError": "Това е най-високата настройка",

--- a/messageBundles/gpii-app-messageBundle_en.json
+++ b/messageBundles/gpii-app-messageBundle_en.json
@@ -39,6 +39,8 @@
         "keyedIn": "Your settings were saved to the Morphic Cloud."
     },
 
+    "gpii_qss_unknownButtonPresenter_notification": "This button is not supported on this version of Morphic. This computer will need to be updated to a newer version of Morphic before this button will work here.",
+
     "gpii_psp_qssWidget_learnMore": "Help / Learn more",
     "gpii_psp_qssWidget_helpAndMoreOptions": "Help & More options",
     "gpii_psp_qssWidget_hideSideCar": "Hide",

--- a/messageBundles/gpii-app-qss-settings_bg.json
+++ b/messageBundles/gpii-app-qss-settings_bg.json
@@ -112,5 +112,10 @@
     "gpii_app_qss_settings_url-customize-qss": {
         "tooltip": "<p>Отваря уеб страница където да промените бутоните в лентата.</p>",
         "title": "Промени бутоните"
+    },
+    "gpii_app_qss_settings_unknown-button": {
+        "tooltip": "<p>Трябва да обновите Morphic, за да използвате този бутон.</p>",
+        "title": "",
+        "tip": ""
     }
 }

--- a/messageBundles/gpii-app-qss-settings_en.json
+++ b/messageBundles/gpii-app-qss-settings_en.json
@@ -152,5 +152,10 @@
     "gpii_app_qss_settings_url-customize-qss": {
         "tooltip": "<p>Open the web tool to customize quickstrip's buttons.</p>",
         "title": "Customize Quickstrip"
+    },
+    "gpii_app_qss_settings_unknown-button": {
+        "tooltip": "<p>Button will not work here until Morphic is updated.</p>",
+        "title": "",
+        "tip": ""
     }
 }

--- a/src/main/common/utils.js
+++ b/src/main/common/utils.js
@@ -365,6 +365,7 @@ gpii.app.filterButtonList = function (siteConfigButtonList, availableButtons) {
     * starting tabindex, adding +10 of each new item.
     */
     var nonTabindex = ["separator", "separator-visible", "grid", "grid-visible"],
+        disabledButtonTypes = ["largeButton", "settingButton", "unknownButton"],
         matchedList = [],
         afterList = [],
         tabindex = 100;
@@ -383,16 +384,25 @@ gpii.app.filterButtonList = function (siteConfigButtonList, availableButtons) {
         } else {
             matchedButton = gpii.app.findButtonById(buttonId, availableButtons);
         }
-        if (matchedButton) {
-            // the separators and grid elements don't need tabindex
-            if (!nonTabindex.includes(buttonId)) {
-                // adding the proper tabindex
-                matchedButton.tabindex = tabindex;
-                tabindex += 10; // increasing the tabindex
-            }
-            // adding button to the matched ones
-            matchedList.push(matchedButton);
+        if (!matchedButton) {
+            matchedButton = {
+                id: buttonId,
+                schema: {
+                    type: "unknown"
+                },
+                path: "UNKNOWN-BUTTON-" + buttonId,
+                buttonTypes: disabledButtonTypes,
+                messageKey: "unknown-button"
+            };
         }
+        // the separators and grid elements don't need tabindex
+        if (!nonTabindex.includes(buttonId)) {
+            // adding the proper tabindex
+            matchedButton.tabindex = tabindex;
+            tabindex += 10; // increasing the tabindex
+        }
+        // adding button to the matched ones
+        matchedList.push(matchedButton);
     });
 
     // creating the afterList

--- a/src/renderer/qss/css/qss.css
+++ b/src/renderer/qss/css/qss.css
@@ -125,6 +125,10 @@ body {
     opacity: 0.4;
 }
 
+.fl-qss-button.fl-qss-unknown {
+    opacity: 0.4 !important;
+}
+
 .fl-qss-button.fl-qss-dimmed {
     background-color: #a7a9ad;
 }

--- a/src/renderer/qss/js/qss.js
+++ b/src/renderer/qss/js/qss.js
@@ -47,6 +47,7 @@
             "mouse":             "gpii.qss.widgetButtonPresenter",
             "snipping-tool":     "gpii.qss.snippingToolPresenter",
             "disabled":          "gpii.qss.disabledButtonPresenter",
+            "unknown":           "gpii.qss.unknownButtonPresenter",
             // custom button grades
             "custom-launch-app": "gpii.qss.customLaunchAppPresenter",
             "custom-open-url":   "gpii.qss.customOpenUrlPresenter",

--- a/src/renderer/qss/js/qssButtons.js
+++ b/src/renderer/qss/js/qssButtons.js
@@ -99,6 +99,7 @@
         styles: {
             activated: "fl-activated",
             disabledButton: "fl-qss-disabled",
+            unknownButton: "fl-qss-unknown",
             smallButton: "fl-qss-smallButton",
             largeButton: "fl-qss-largeButton",
             settingButton: "fl-qss-settingButton",

--- a/src/renderer/qss/js/qssServiceButtons.js
+++ b/src/renderer/qss/js/qssServiceButtons.js
@@ -123,6 +123,41 @@
     };
 
     /**
+     * Inherits from `gpii.qss.buttonPresenter` and handles interactions with the unknown type
+     * QSS buttons (all that don't have definitions).
+     */
+    fluid.defaults("gpii.qss.unknownButtonPresenter", {
+        gradeNames: ["gpii.qss.buttonPresenter"],
+        model: {
+            messages: {
+                notification: null
+            }
+        },
+        invokers: {
+            activate: {
+                funcName: "gpii.qss.unknownButtonPresenter.activate",
+                args: [
+                    "{that}",
+                    "{list}"
+                ]
+            }
+        }
+    });
+
+    /**
+     * A custom function for handling activation of the unknown type QSS buttons. It just shows
+     * the proper notification why this button it's disabled.
+     * @param {gpii.qss.unknownButtonPresenter} that - The `gpii.qss.unknownButtonPresenter` instance.
+     * @param {gpii.qss.list} qssList - The `gpii.qss.list` instance.
+     */
+    gpii.qss.unknownButtonPresenter.activate = function (that, qssList) {
+        qssList.events.onNotificationRequired.fire({
+            description: that.model.messages.notification,
+            closeOnBlur: true
+        });
+    };
+
+    /**
      * Inherits from `gpii.qss.buttonPresenter` and handles interactions with the "More..."
      * QSS button.
      */


### PR DESCRIPTION
This adds new unknown type of buttons with his handler (showing the proper tooltip and when click it a specific notification message) for both standard buttons that are missing from settings.json definitions, and custom buttons from unknown types, or missing required data fields.

For testing purposes you can add random non-existing buttonId in siteConfig > qss > buttonList, or in the same variable change one of the custom button types for something different that "WEB", "APP", or "KEY".