### PR TITLE
GPII-4195: Add 1909 and LTSC Windows 10 version to Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,24 +10,20 @@ ram = ENV["VM_RAM"] || 2048
 
 Vagrant.configure(2) do |config|
 
-  config.vm.box = "inclusivedesign/windows10-eval-x64-Apps"
-  config.vm.guest = :windows
-
-  config.vm.communicator = "winrm"
-  config.winrm.username = "vagrant"
-  config.winrm.password = "vagrant"
-  config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct:true
-  config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "rdp", auto_correct:true
-
-  config.vm.provider :virtualbox do |vm|
-    vm.gui = true
-    vm.customize ["modifyvm", :id, "--memory", ram]
-    vm.customize ["modifyvm", :id, "--cpus", cpus]
-    vm.customize ["modifyvm", :id, "--vram", "256"]
-    vm.customize ["modifyvm", :id, "--accelerate3d", "off"]
-    vm.customize ["modifyvm", :id, "--audio", "null", "--audiocontroller", "hda"]
-    vm.customize ["modifyvm", :id, "--ioapic", "on"]
-    vm.customize ["setextradata", "global", "GUI/SuppressMessages", "all"]
+  ["LTSC", "1909"].each do |flavour|
+    config.vm.define "#{flavour}" do |latest|
+      latest.vm.box = "gpii-ops/windows10-#{flavour}-eval-x64-universal"
+      latest.vm.provider :virtualbox do |vm|
+        vm.gui = true
+        vm.customize ["modifyvm", :id, "--memory", ram]
+        vm.customize ["modifyvm", :id, "--cpus", cpus]
+        vm.customize ["modifyvm", :id, "--vram", "256"]
+        vm.customize ["modifyvm", :id, "--accelerate3d", "off"]
+        vm.customize ["modifyvm", :id, "--audio", "null", "--audiocontroller", "hda"]
+        vm.customize ["modifyvm", :id, "--ioapic", "on"]
+        vm.customize ["setextradata", "global", "GUI/SuppressMessages", "all"]
+      end
+    end
   end
 
   config.vm.provision "shell", path: "provisioning/Build.ps1", args: "-originalBuildScriptPath \"C:\\vagrant\\provisioning\\\""


### PR DESCRIPTION
This PR depends on https://github.com/GPII/ci-service/pull/75. Both should be merged at the same time, otherwise the CI will fail.