### PR TITLE
GPII-4474: Fix the footerTip issue (showing on every menuWidget)

### DIFF
--- a/src/main/qss.js
+++ b/src/main/qss.js
@@ -832,11 +832,10 @@ gpii.app.qssWrapper.applySettingTranslation = function (qssSettingMessages, sett
             translatedSetting.switchTitle = message.switchTitle;
         }
 
-        // footerTip
         translatedSetting.widget = translatedSetting.widget || {};
-        if (fluid.isValue(message.footerTip)) {
-            translatedSetting.widget.footerTip = message.footerTip;
-        }
+
+        // footerTip
+        translatedSetting.widget.footerTip = message.footerTip || "";
 
         // sideCar
         translatedSetting.sideCar = message.sideCar || "";


### PR DESCRIPTION
This fixes the small bug when you open the Color Vision first and then any menuWidget type button (Languages, High Contrast, etc.) and the color vision footerTip still shows.