### PR TITLE
GPII-4049: Volume Control v3

### DIFF
--- a/src/main/common/utils.js
+++ b/src/main/common/utils.js
@@ -496,6 +496,38 @@ gpii.app.getVolumeValue = function (browserWindow, messageChannel) {
 };
 
 /**
+ * A standard volume control, it can simulate volume up, down and mute
+ * @param {String} command - accepts "up", "down" and "mute" as commands
+ */
+gpii.app.volumeControl = function (command) {
+    var WM_APPCOMMAND = 0x319, // https://docs.microsoft.com/windows/win32/inputdev/wm-appcommand
+        APPCOMMAND_VOLUME_MUTE = 8,
+        APPCOMMAND_VOLUME_DOWN = 9,
+        APPCOMMAND_VOLUME_UP = 10,
+        action = false; // by default there will be no action taken
+
+    // determine which command to use
+    switch (command) {
+    case "up":
+        action = APPCOMMAND_VOLUME_UP;
+        break;
+    case "down":
+        action = APPCOMMAND_VOLUME_DOWN;
+        break;
+    case "mute":
+        action = APPCOMMAND_VOLUME_MUTE;
+        break;
+    }
+
+    // Send the volume up/down command directly to the task tray (rather than a simulated key press)
+    if (action) {
+        gpii.windows.messages.sendMessage("Shell_TrayWnd", WM_APPCOMMAND, 0, gpii.windows.makeLong(0, action));
+    } else {
+        fluid.log(fluid.logLevel.WARN, "gpii.app.volumeControl: Invalid volume command - " + command);
+    }
+};
+
+/**
  * Looks into secondary data's `settings` value and compare the values with the
  * provided old value
  * @param {Object} value - The setting which has been altered via the QSS or

--- a/src/main/common/utils.js
+++ b/src/main/common/utils.js
@@ -471,31 +471,6 @@ gpii.app.ejectUSB = function (browserWindow, messageChannel, messages) {
 };
 
 /**
- * Get the actual volume value. If there are an error or no value return the default
- * volume value
- * @param {Object} browserWindow - An Electron `BrowserWindow` object.
- * @param {String} messageChannel - The channel to which the message should be sent.
- * @return {Number} - The actual value of the volume
- */
-gpii.app.getVolumeValue = function (browserWindow, messageChannel) {
-    var defaultVolumeValue = 0.5;
-    try {
-        var volumeValue = gpii.windows.nativeSettingsHandler.GetVolume().value;
-
-        if (isNaN(volumeValue)) {
-            gpii.app.notifyWindow(browserWindow, messageChannel, defaultVolumeValue);
-            return defaultVolumeValue;
-        } else {
-            gpii.app.notifyWindow(browserWindow, messageChannel, volumeValue);
-            return volumeValue;
-        }
-    } catch (err) {
-        fluid.log(fluid.logLevel.WARN, err);
-        return defaultVolumeValue;
-    }
-};
-
-/**
  * A standard volume control, it can simulate volume up, down and mute
  * @param {String} command - accepts "up", "down" and "mute" as commands
  */

--- a/src/main/dialogs/quickSetStrip/qssWidgetDialog.js
+++ b/src/main/dialogs/quickSetStrip/qssWidgetDialog.js
@@ -112,7 +112,6 @@ fluid.defaults("gpii.app.qssWidget", {
                     // USB related events
                     onQssOpenUsbRequested: null,
                     onQssUnmountUsbRequested: null,
-                    onQssGetVolumeRequested: null,
                     onQssVolumeControl: null,
                     onQssReApplyPreferencesRequired: null,
                     onQssGetEnvironmentalLoginKeyRequested: null,
@@ -157,13 +156,6 @@ fluid.defaults("gpii.app.qssWidget", {
                             "{qssWidget}.dialog",
                             "{arguments}.0", // messageChannel
                             "{arguments}.1" // messages
-                        ]
-                    },
-                    onQssGetVolumeRequested: {
-                        funcName: "gpii.app.getVolumeValue",
-                        args: [
-                            "{qssWidget}.dialog",
-                            "{arguments}.0" // messageChannel
                         ]
                     },
                     onQssVolumeControl: {

--- a/src/main/dialogs/quickSetStrip/qssWidgetDialog.js
+++ b/src/main/dialogs/quickSetStrip/qssWidgetDialog.js
@@ -113,6 +113,7 @@ fluid.defaults("gpii.app.qssWidget", {
                     onQssOpenUsbRequested: null,
                     onQssUnmountUsbRequested: null,
                     onQssGetVolumeRequested: null,
+                    onQssVolumeControl: null,
                     onQssReApplyPreferencesRequired: null,
                     onQssGetEnvironmentalLoginKeyRequested: null,
                     onLearnMoreClicked: null,
@@ -164,6 +165,10 @@ fluid.defaults("gpii.app.qssWidget", {
                             "{qssWidget}.dialog",
                             "{arguments}.0" // messageChannel
                         ]
+                    },
+                    onQssVolumeControl: {
+                        funcName: "gpii.app.volumeControl",
+                        args: [ "{arguments}.0" ]
                     },
                     onQssReApplyPreferencesRequired: {
                         funcName: "{app}.reApplyPreferences"

--- a/src/main/gpiiConnector.js
+++ b/src/main/gpiiConnector.js
@@ -765,7 +765,6 @@ fluid.defaults("gpii.app.dev.gpiiConnector.qss", {
         "http://registry\\.gpii\\.net/common/DPIScale": { value: 0 },
         "http://registry\\.gpii\\.net/common/highContrastTheme": { value: "regular-contrast" },
         "http://registry\\.gpii\\.net/common/selfVoicing/enabled": { value: false },
-        "http://registry\\.gpii\\.net/common/volume": { value: gpii.app.getVolumeValue() },
         "http://registry\\.gpii\\.net/applications/com\\.microsoft\\.windows\\.colorFilters.FilterType": {value: 0 },
         // use the initial value of the language as default setting
         "http://registry\\.gpii\\.net/common/language": { value: "{systemLanguageListener}.model.configuredLanguage" },

--- a/src/main/qss.js
+++ b/src/main/qss.js
@@ -50,8 +50,7 @@ fluid.defaults("gpii.app.qssWrapper", {
 
         // paths might be needed for some reason
         settingPaths: {
-            language: "http://registry\\.gpii\\.net/common/language",
-            volume: "http://registry\\.gpii\\.net/common/volume"
+            language: "http://registry\\.gpii\\.net/common/language"
         },
 
         settingMessagesPrefix: "gpii_app_qss_settings",
@@ -685,20 +684,11 @@ gpii.app.qssWrapper.loadSettings = function (assetsManager, installedLanguages, 
         return setting.path === settingOptions.settingPaths.language;
     });
 
-    var volumeSetting = fluid.find_if(loadedSettings, function (setting) {
-        return setting.path === settingOptions.settingPaths.volume;
-    });
-
     // we double check if this setting exists because can be disabled via siteConfig's buttonList
     if (fluid.isValue(languageSetting)) {
         gpii.app.qssWrapper.populateLanguageSettingOptions(settingOptions, locale, installedLanguages, languageSetting);
         // sync the language value as well
         languageSetting.value = locale;
-    }
-
-    // we double check if this setting exists because can be disabled via siteConfig's buttonList
-    if (fluid.isValue(volumeSetting)) {
-        volumeSetting.value = gpii.windows.nativeSettingsHandler.GetVolume().value;
     }
 
     /*
@@ -1032,7 +1022,7 @@ fluid.defaults("gpii.app.qssInWrapper", {
 fluid.defaults("gpii.app.undoInWrapper", {
     gradeNames: "gpii.app.undoStack",
     // paths of settings that are not undoable
-    unwatchedSettings: ["appTextZoom"],
+    unwatchedSettings: ["appTextZoom", "volume-control"],
 
     listeners: {
         "onChangeUndone.applyChange": {

--- a/src/renderer/qss/js/qssSettingButtons.js
+++ b/src/renderer/qss/js/qssSettingButtons.js
@@ -179,8 +179,8 @@
     });
 
     /**
-     * State of the Volume button. If the value is 0 the state of the button is ON, any other value is OFF.
-     * @typedef {Number} volumeState
+     * State of the Volume button. If the value is `true` the state of the button is ON.
+     * @typedef {Boolean} volumeState
     */
 
     /**
@@ -189,7 +189,7 @@
      * @param {volumeState} value - The state of the button.
      */
     gpii.qss.volumeButtonPresenter.hideTitle = function (titleElem, value) {
-        if (value === 0) {
+        if (value) {
             titleElem.hide();
         } else {
             titleElem.show();
@@ -197,13 +197,13 @@
     };
 
     /**
-     * If available in the setting's schema, shows the specified image for the button when the value of setting is 0.
+     * If available in the setting's schema, shows the specified image for the button when the volume switch is ON.
      * @param {jQuery} imageElem - The jQuery object corresponding to the image of the button.
      * @param {String} image - The path to the image.
      * @param {volumeState} value - The state of the button.
      */
     gpii.qss.volumeButtonPresenter.renderImage = function (imageElem, image, value) {
-        if (image && value === 0) {
+        if (image && value) {
             var maskImageValue = fluid.stringTemplate("url(\"%image\")", {
                 image: image
             });
@@ -220,28 +220,28 @@
     /**
      * Returns the caption of the toggle button that needs to be shown below the button's
      * title in case the state of the button is "on".
-     * In the case of the Volume widget, the caption message is shown only when the value is 0.
+     * In the case of the Volume widget, the caption message is shown only when the volume switch is ON.
      * @param {volumeState} value - The state of the button.
      * @param {Object} messages - An object containing internationalizable messages for
      * this component.
-     * @param {Component} that - The `gpii.qss.volumeButtonPresenter` instance.
+     * @param {gpii.qss.volumeButtonPresenter} that - The `gpii.qss.volumeButtonPresenter` instance.
      * @return {String} The caption message for the toggle button.
      */
     gpii.qss.volumeButtonPresenter.getCaption = function (value, messages, that) {
         that.toggleStyle(value);
         that.renderImage(value);
         that.hideTitle(value);
-        return value === 0 ? messages.caption : "";
+        return value ? messages.caption : "";
     };
 
     /**
-     * Change the color of the "Volume & Mute" button if the value is 0.
+     * Change the color of the "Volume & Mute" button if the volume switch is ON.
      * @param {jQuery} container - The jQuery container object
      * @param {String} style - Contains css class
      * @param {volumeState} value - The state of the button.
      */
     gpii.qss.volumeButtonPresenter.toggleStyle = function (container, style, value) {
-        if (value === 0) {
+        if (value) {
             container.addClass(style);
         } else {
             container.removeClass(style);

--- a/src/renderer/qssWidget/js/qssVolumeWidget.js
+++ b/src/renderer/qssWidget/js/qssVolumeWidget.js
@@ -97,6 +97,22 @@
                     },
                     events: {
                         onNotificationRequired: "{volume}.events.onNotificationRequired"
+                    },
+                    invokers: {
+                        activateIncBtn: {
+                            funcName: "gpii.qssWidget.volume.activateButton",
+                            args: [
+                                "up", // volume up
+                                "{channelNotifier}.events.onQssVolumeControl" // volume control event
+                            ]
+                        },
+                        activateDecBtn: {
+                            funcName: "gpii.qssWidget.volume.activateButton",
+                            args: [
+                                "down", // volume down
+                                "{channelNotifier}.events.onQssVolumeControl" // volume control event
+                            ]
+                        }
                     }
                 }
             },
@@ -126,6 +142,18 @@
             }
         }
     });
+
+
+    /**
+     * Invoked whenever the either button is activated. Fires the onQssVolumeControl
+     * with the appropriate action ("up", or "down"). This activates the windows control
+     * for volume up or down
+     * @param {String} action - it can be up or down
+     * @param {fluid.event} volumeControlEvent - the onQssVolumeControl event
+     */
+    gpii.qssWidget.volume.activateButton = function (action, volumeControlEvent) {
+        volumeControlEvent.fire(action);
+    };
 
     /**
      * Set the actual volume value in the case the volume is changed through the Windows itself

--- a/src/renderer/qssWidget/js/qssVolumeWidget.js
+++ b/src/renderer/qssWidget/js/qssVolumeWidget.js
@@ -41,9 +41,7 @@
         model: {
             setting: {},
             messages: {},
-            value: "{that}.model.setting.value",
-            previousValue: "{that}.model.setting.schema.previousValue",
-            messageChannel: "volumeMessageChannel" // Channel listening for messages related volume/mute functionality
+            value: "{that}.model.setting.value"
         },
         events: {
             onHeightChanged: null
@@ -53,27 +51,16 @@
                 this: "{that}.dom.helpImage",
                 method: "attr",
                 args: ["src", "{that}.model.setting.schema.helpImage"]
-            },
-            "onCreate.registerIpcListener": {
-                funcName: "gpii.psp.registerIpcListener",
-                args: ["{that}.model.messageChannel", "{volume}.loadActualValue"]
-            },
-            "onCreate.sendGetVolumeRequest": {
-                funcName: "{channelNotifier}.events.onQssGetVolumeRequested.fire",
-                args: ["{that}.model.messageChannel"]
             }
         },
         modelListeners: {
-            value: {
-                funcName: "gpii.qssWidget.volume.updateSwitchState",
-                args: ["{switchButton}", "{change}.value"]
+            "setting.value": {
+                func: "{channelNotifier}.events.onQssWidgetSettingAltered.fire",
+                args: ["{that}.model.setting"],
+                includeSource: "fromWidget"
             }
         },
         invokers: {
-            loadActualValue: {
-                funcName: "gpii.qssWidget.volume.loadActualValue",
-                args: ["{volume}", "{arguments}.0"]
-            },
             calculateHeight: {
                 funcName: "gpii.qssWidget.calculateHeight",
                 args: [
@@ -90,19 +77,14 @@
                 options: {
                     sounds: "{volume}.options.sounds",
                     model: {
-                        setting: "{volume}.model.setting",
-                        messages: "{volume}.model.messages",
-                        previousValue: "{volume}.model.previousValue",
-                        value: "{volume}.model.setting.value"
-                    },
-                    events: {
-                        onNotificationRequired: "{volume}.events.onNotificationRequired"
+                        messages: "{volume}.model.messages"
                     },
                     invokers: {
                         activateIncBtn: {
                             funcName: "gpii.qssWidget.volume.activateButton",
                             args: [
                                 "up", // volume up
+                                "{volume}",
                                 "{channelNotifier}.events.onQssVolumeControl" // volume control event
                             ]
                         },
@@ -110,6 +92,7 @@
                             funcName: "gpii.qssWidget.volume.activateButton",
                             args: [
                                 "down", // volume down
+                                "{volume}",
                                 "{channelNotifier}.events.onQssVolumeControl" // volume control event
                             ]
                         }
@@ -121,12 +104,7 @@
                 container: "{that}.dom.switch",
                 options: {
                     model: {
-                        enabled: {
-                            expander: {
-                                funcName: "gpii.qssWidget.volume.transformValue",
-                                args: ["{volume}.model.setting.value"]
-                            }
-                        },
+                        enabled: "{volume}.model.value",
                         messages: {
                             on: "{volume}.model.messages.on",
                             off: "{volume}.model.messages.off"
@@ -135,7 +113,10 @@
                     invokers: {
                         toggleModel: {
                             funcName: "gpii.qssWidget.volume.toggleModel",
-                            args: ["{that}", "{volume}", "{stepper}", "{channelNotifier}.events.onQssWidgetSettingAltered"]
+                            args: [
+                                "{that}",
+                                "{channelNotifier}.events.onQssVolumeControl" // volume control event
+                            ]
                         }
                     }
                 }
@@ -148,77 +129,31 @@
      * Invoked whenever the either button is activated. Fires the onQssVolumeControl
      * with the appropriate action ("up", or "down"). This activates the windows control
      * for volume up or down
-     * @param {String} action - it can be up or down
-     * @param {fluid.event} volumeControlEvent - the onQssVolumeControl event
+     * @param {String} action - it can be up or down.
+     * @param {gpii.qssWidget.volume} volumeWidget - The `gpii.psp.widgets.volume.switchButton` instance.
+     * @param {fluid.event} volumeControlEvent - the onQssVolumeControl event.
      */
-    gpii.qssWidget.volume.activateButton = function (action, volumeControlEvent) {
+    gpii.qssWidget.volume.activateButton = function (action, volumeWidget, volumeControlEvent) {
         volumeControlEvent.fire(action);
-    };
 
-    /**
-     * Set the actual volume value in the case the volume is changed through the Windows itself
-     * @param {Component} that - The `gpii.psp.widgets.volume` instance.
-     * @param {Number} value - The value of the setting.
-     */
-    gpii.qssWidget.volume.loadActualValue = function (that, value) {
-        that.applier.change("value", value, null, "fromWidget");
-    };
-
-    /**
-     * Invoked whenever the volume value is changed and updating the state of the
-     * volume switch button.
-     * @param {Component} switchButton - The `gpii.psp.widgets.volume.switchButton` instance.
-     * @param {Number} value - The value of the setting.
-     */
-    gpii.qssWidget.volume.updateSwitchState = function (switchButton, value) {
-        if (!value !== switchButton.model.enabled) {
-            switchButton.applier.change("enabled", !switchButton.model.enabled, null, "fromWidget");
-        } else if (value !== 0 && switchButton.model.enabled) {
-            switchButton.applier.change("enabled", !switchButton.model.enabled, null, "fromWidget");
+        // Switch mute toggle if already muted
+        if (volumeWidget.model.value) {
+            volumeWidget.applier.change("value", false, null, "fromWidget");
         }
-    };
-
-    /**
-     * Transforms a number value to boolean.
-     * @param {Number} value - The value of the setting
-     * @return {Boolean} The modified value.
-     */
-    gpii.qssWidget.volume.transformValue = function (value) {
-        return !value;
     };
 
     /**
      * Invoked whenever the user has activated the "switch" UI element (either
      * by clicking on it or pressing "Space" or "Enter"). What this function
-     * does is to update model value and update settings.
-     * @param {Component} that - The `gpii.psp.widgets.volume.switchButton` instance.
-     * @param {Component} volumeWidget - The `gpii.psp.widgets.volume` instance.
-     * @param {Component} stepper - The `gpii.psp.widgets.volumeStepper instance.
-     * #param {EventListener} event - onQssWidgetSettingAltered event
+     * does is to change the `enabled` model property to its opposite value and update settings.
+     * @param {gpii.qssWidget.volume.switchButton} that - The `gpii.psp.widgets.switch` instance.
+     * @param {fluid.event} volumeControlEvent - the onQssVolumeControl event.
      */
-    gpii.qssWidget.volume.toggleModel = function (that, volumeWidget, stepper) {
-        if (!volumeWidget.model.setting.value && !that.model.enabled) {
-            return;
-        }
+    gpii.qssWidget.volume.toggleModel = function (that, volumeControlEvent) {
+        // toggle the widget
+        that.applier.change("enabled", !that.model.enabled, null, "fromWidget");
 
-        if (volumeWidget.model.setting.value !== 0) {
-            volumeWidget.applier.change("previousValue", volumeWidget.model.setting.value, null, "fromWidget");
-            stepper.applier.change("previousValue", volumeWidget.model.setting.value, null, "fromWidget");
-            that.applier.change("previousValue", volumeWidget.model.setting.value, null, "fromWidget");
-        }
-
-        if (!that.model.enabled && volumeWidget.model.setting.value !== 0) {
-            volumeWidget.applier.change("value", 0, null, "fromWidget");
-            stepper.applier.change("value", 0, null, "fromWidget");
-
-        } else {
-            volumeWidget.applier.change("value", volumeWidget.model.previousValue, null, "fromWidget");
-            stepper.applier.change("value", volumeWidget.model.previousValue, null, "fromWidget");
-
-        }
-
-        // update the volume setting
-        // This event has already been triggered in the previous block.
-        // event.fire(volumeWidget.model.setting);
+        // use the onQssVolumeControl event to send the mute event
+        volumeControlEvent.fire("mute");
     };
 })(fluid);

--- a/src/renderer/qssWidget/js/qssWidget.js
+++ b/src/renderer/qssWidget/js/qssWidget.js
@@ -102,6 +102,7 @@
 
             // Volume & Mute related event
             onQssGetVolumeRequested: null,
+            onQssVolumeControl: null,
             onQssReApplyPreferencesRequired: null,
             onQssGetEnvironmentalLoginKeyRequested: null,
             onSideCarToggled: null
@@ -301,6 +302,7 @@
                         onQssUnmountUsbRequested:        "{qssWidget}.events.onQssUnmountUsbRequested",
                         // Volume button
                         onQssGetVolumeRequested:         "{qssWidget}.events.onQssGetVolumeRequested",
+                        onQssVolumeControl:              "{qssWidget}.events.onQssVolumeControl",
                         onQssReApplyPreferencesRequired: "{qssWidget}.events.onQssReApplyPreferencesRequired",
                         onQssGetEnvironmentalLoginKeyRequested: "{qssWidget}.events.onQssGetEnvironmentalLoginKeyRequested",
                         onMetric:                        "{qssWidget}.events.onMetric",

--- a/src/renderer/qssWidget/js/qssWidget.js
+++ b/src/renderer/qssWidget/js/qssWidget.js
@@ -101,7 +101,6 @@
             onQssUnmountUsbRequested: null,
 
             // Volume & Mute related event
-            onQssGetVolumeRequested: null,
             onQssVolumeControl: null,
             onQssReApplyPreferencesRequired: null,
             onQssGetEnvironmentalLoginKeyRequested: null,
@@ -301,7 +300,6 @@
                         onQssOpenUsbRequested:           "{qssWidget}.events.onQssOpenUsbRequested",
                         onQssUnmountUsbRequested:        "{qssWidget}.events.onQssUnmountUsbRequested",
                         // Volume button
-                        onQssGetVolumeRequested:         "{qssWidget}.events.onQssGetVolumeRequested",
                         onQssVolumeControl:              "{qssWidget}.events.onQssVolumeControl",
                         onQssReApplyPreferencesRequired: "{qssWidget}.events.onQssReApplyPreferencesRequired",
                         onQssGetEnvironmentalLoginKeyRequested: "{qssWidget}.events.onQssGetEnvironmentalLoginKeyRequested",

--- a/testData/qss/settings.json
+++ b/testData/qss/settings.json
@@ -65,16 +65,12 @@
         "path": "volume-control",
         "schema": {
             "type": "volume",
-            "min": 0,
-            "max": 1,
-            "divisibleBy": 0.02,
-            "previousValue": 0.5,
             "image": "volume-mute.svg"
         },
         "buttonTypes": ["largeButton", "settingButton"],
         "tabindex": 125,
         "messageKey": "common-volume",
-        "value": 0.5,
+        "value": false,
         "learnMoreLink": "https://morphic.world/basics/learn-more-about-quickstrip#volume-mute"
 
     }, {

--- a/testData/qss/settings.json
+++ b/testData/qss/settings.json
@@ -62,7 +62,7 @@
         "learnMoreLink": "https://morphic.world/basics/learn-more-about-quickstrip#textzoom"
     }, {
         "id": "volume",
-        "path": "http://registry\\.gpii\\.net/common/volume",
+        "path": "volume-control",
         "schema": {
             "type": "volume",
             "min": 0,

--- a/tests/fixtures/qssSettings.json
+++ b/tests/fixtures/qssSettings.json
@@ -288,20 +288,16 @@
         "value": ""
     }, {
         "id": "volume",
-        "path": "http://registry\\.gpii\\.net/common/volume",
+        "path": "volume-control",
         "schema": {
             "type": "volume",
-            "min": 0,
-            "max": 1,
-            "divisibleBy": 0.1,
-            "default": 0.5,
             "image": "language.svg",
             "helpImage": "readAloud.png"
         },
         "buttonTypes": ["largeButton", "settingButton"],
         "tabindex": 90,
         "messageKey": "common-volume",
-        "value": 0.5,
+        "value": false,
         "learnMoreLink": "https://morphic.world/help/qsshelp#volume"
 
     }, {

--- a/tests/qss/QssTestDefs.js
+++ b/tests/qss/QssTestDefs.js
@@ -235,7 +235,7 @@ var qssInstalledLanguages = [
 
 gpii.tests.qss.testDefs = {
     name: "QSS Widget integration tests",
-    expect: 94,
+    expect: 93,
     config: {
         configName: "gpii.tests.dev.config",
         configPath: "tests/configs"

--- a/tests/qss/qssWidget-volumeTests.js
+++ b/tests/qss/qssWidget-volumeTests.js
@@ -72,14 +72,6 @@ gpii.tests.qss.volumeTests = [
             clickVolumeSwitchBtn
         ],
         resolve: "fluid.identity"
-    }, { // ... should notify the core
-        event: "{that}.app.settingsBroker.events.onSettingApplied",
-        listener: "jqUnit.assertLeftHand",
-        args: [
-            "Change event was fired from QSS widget interaction.",
-            { path: "http://registry\\.gpii\\.net/common/volume", value: 0 },
-            "{arguments}.0"
-        ]
     }, { // ... and the button image should be visible
         task: "gpii.test.executeJavaScriptInWebContents",
         args: [


### PR DESCRIPTION
Moving from a settings based Volume/Mute control, to one that uses Windows real-time commands. With that we no-longer trying to read the current volume, and don't track it internally as well. Just sending volume up/down and mute commands on key presses.

**Notes:**
* As we don't have the functionality to read Windows's mute state we don't know it and assume that it's not muted. So if Windows's muted and you open QSS looks like it's not, so when you click the "Mute" button it will unmute Windows, but will show that it's muted in QSS (toggle on, and the button will show that it's muted). So the buttons will work properly, but the UX will be reversed. Gregg knows about this, and accepted it in order to finish this quicker.
* If you click on the "Mute" button this will toggle Windows's mute, and show the Mute state in QSS (the button will be red, and button's text will change). If you click Mute again this will reverse, the same goes if you click Volume Up as well, so the Volume Up will act as Unmute too.